### PR TITLE
RCON Manager

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,6 +25,7 @@ DB_MIGRATE_VERBOSE=false
 
 # Log
 LOG_LEVEL="info"
+LOG_SHOW_GIN=false
 LOG_FILE=""
 
 # Debug

--- a/internal/chat_processor/chat_processor.go
+++ b/internal/chat_processor/chat_processor.go
@@ -1,0 +1,233 @@
+package chat_processor
+
+import (
+	"context"
+	"database/sql"
+	"strings"
+	"sync"
+
+	"github.com/google/uuid"
+	"github.com/rs/zerolog/log"
+	"go.codycody31.dev/squad-aegis/internal/rcon"
+	"go.codycody31.dev/squad-aegis/internal/rcon_manager"
+)
+
+// Command represents a chat command
+type Command struct {
+	Name        string
+	Description string
+	Usage       string
+	Handler     func(ctx context.Context, serverID uuid.UUID, message rcon.Message, args []string) (string, error)
+	AdminOnly   bool
+}
+
+// ChatProcessor processes chat messages and handles commands
+type ChatProcessor struct {
+	rconManager *rcon_manager.RconManager
+	db          *sql.DB
+	commands    map[string]Command
+	mu          sync.RWMutex
+	ctx         context.Context
+	cancel      context.CancelFunc
+}
+
+// NewChatProcessor creates a new chat processor
+func NewChatProcessor(ctx context.Context, rconManager *rcon_manager.RconManager, db *sql.DB) *ChatProcessor {
+	ctx, cancel := context.WithCancel(ctx)
+	return &ChatProcessor{
+		rconManager: rconManager,
+		db:          db,
+		commands:    make(map[string]Command),
+		ctx:         ctx,
+		cancel:      cancel,
+	}
+}
+
+// RegisterCommand registers a command
+func (p *ChatProcessor) RegisterCommand(command Command) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.commands[strings.ToLower(command.Name)] = command
+}
+
+// Start starts the chat processor
+func (p *ChatProcessor) Start() {
+	// Register default commands
+	p.registerDefaultCommands()
+
+	// Start processing chat messages
+	p.rconManager.ProcessChatMessages(p.ctx, p.handleChatMessage)
+
+	log.Info().Msg("Chat processor started")
+}
+
+// Stop stops the chat processor
+func (p *ChatProcessor) Stop() {
+	p.cancel()
+	log.Info().Msg("Chat processor stopped")
+}
+
+// handleChatMessage handles a chat message
+func (p *ChatProcessor) handleChatMessage(serverID uuid.UUID, message rcon.Message) {
+	// Log the message
+	log.Debug().
+		Str("serverID", serverID.String()).
+		Str("chatType", message.ChatType).
+		Str("playerName", message.PlayerName).
+		Str("message", message.Message).
+		Msg("Chat message received")
+
+	// Check if the message is a command
+	if !strings.HasPrefix(message.Message, "!") {
+		return
+	}
+
+	// Parse the command
+	parts := strings.Fields(message.Message[1:])
+	if len(parts) == 0 {
+		return
+	}
+
+	commandName := strings.ToLower(parts[0])
+	args := parts[1:]
+
+	// Get the command
+	p.mu.RLock()
+	command, exists := p.commands[commandName]
+	p.mu.RUnlock()
+
+	if !exists {
+		return
+	}
+
+	// Check if the command is admin-only
+	if command.AdminOnly {
+		isAdmin, err := p.isPlayerAdmin(p.ctx, serverID, message.SteamID)
+		if err != nil {
+			log.Error().
+				Err(err).
+				Str("serverID", serverID.String()).
+				Str("steamID", message.SteamID).
+				Msg("Failed to check if player is admin")
+			return
+		}
+
+		if !isAdmin {
+			// Send a message to the player
+			p.sendDirectMessage(serverID, "You don't have permission to use this command.", message.SteamID)
+			return
+		}
+	}
+
+	// Execute the command
+	response, err := command.Handler(p.ctx, serverID, message, args)
+	if err != nil {
+		log.Error().
+			Err(err).
+			Str("serverID", serverID.String()).
+			Str("command", commandName).
+			Msg("Failed to execute command")
+
+		// Send error message to the player
+		p.sendDirectMessage(serverID, "Something went wrong, please try again later.", message.SteamID)
+		return
+	}
+
+	// Send the response to the player if there is one
+	if response != "" {
+		p.sendDirectMessage(serverID, response, message.SteamID)
+	}
+}
+
+// isPlayerAdmin checks if a player is an admin
+func (p *ChatProcessor) isPlayerAdmin(ctx context.Context, serverID uuid.UUID, steamID string) (bool, error) {
+	// Query the database to check if the player is an admin
+	var count int
+	err := p.db.QueryRowContext(ctx, `
+		SELECT COUNT(*) FROM server_admins sa
+		JOIN users u ON sa.user_id = u.id
+		WHERE sa.server_id = $1 AND u.steam_id = $2
+	`, serverID, steamID).Scan(&count)
+
+	if err != nil {
+		return false, err
+	}
+
+	return count > 0, nil
+}
+
+// registerDefaultCommands registers the default commands
+func (p *ChatProcessor) registerDefaultCommands() {
+	p.RegisterCommand(Command{
+		Name:        "admin",
+		Description: "Calls an admin",
+		Usage:       "!admin [message]",
+		Handler:     p.handleAdminCommand,
+		AdminOnly:   false,
+	})
+}
+
+// handleAdminCommand handles the admin command
+func (p *ChatProcessor) handleAdminCommand(ctx context.Context, serverID uuid.UUID, message rcon.Message, args []string) (string, error) {
+	// Get all admins for the server
+	rows, err := p.db.QueryContext(ctx, `
+		SELECT u.username, u.steam_id
+		FROM server_admins sa
+		JOIN users u ON sa.user_id = u.id
+		WHERE sa.server_id = $1
+	`, serverID)
+	if err != nil {
+		return "", err
+	}
+	defer rows.Close()
+
+	// Build the admin message
+	adminMessage := message.PlayerName + " is requesting admin assistance"
+	if len(args) > 0 {
+		adminMessage += ": " + strings.Join(args, " ")
+	}
+
+	// TODO: Discord integration: ie: send message to discord channel
+
+	// Send a message to all admins
+	for rows.Next() {
+		var username string
+		var steamID string
+		if err := rows.Scan(&username, &steamID); err != nil {
+			log.Error().
+				Err(err).
+				Str("serverID", serverID.String()).
+				Msg("Failed to scan admin row")
+			continue
+		}
+
+		// Send a direct message to the admin
+		p.sendDirectMessage(serverID, adminMessage, steamID)
+	}
+
+	if err := rows.Err(); err != nil {
+		log.Error().
+			Err(err).
+			Str("serverID", serverID.String()).
+			Msg("Error iterating admin rows")
+	}
+
+	return "Your request has been sent to the admins.", nil
+}
+
+// sendDirectMessage sends a direct message to a player
+func (p *ChatProcessor) sendDirectMessage(serverID uuid.UUID, message string, steamID string) {
+	// Format the command to send a direct message to the player
+	command := "AdminWarn " + steamID + " " + message
+
+	// Execute the command
+	_, err := p.rconManager.ExecuteCommand(serverID, command)
+	if err != nil {
+		log.Error().
+			Err(err).
+			Str("serverID", serverID.String()).
+			Str("steamID", steamID).
+			Str("message", message).
+			Msg("Failed to send direct message")
+	}
+}

--- a/internal/rcon_manager/rcon_manager.go
+++ b/internal/rcon_manager/rcon_manager.go
@@ -114,7 +114,7 @@ func (m *RconManager) broadcastEvent(event RconEvent) {
 }
 
 // ConnectToServer connects to an RCON server
-func (m *RconManager) ConnectToServer(serverID uuid.UUID, host string, port int, password string, forceReconnect bool) error {
+func (m *RconManager) ConnectToServer(serverID uuid.UUID, host string, port int, password string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -131,11 +131,11 @@ func (m *RconManager) ConnectToServer(serverID uuid.UUID, host string, port int,
 		conn.mu.Lock()
 		defer conn.mu.Unlock()
 
-		// If connection is disconnected or forceReconnect is true, reconnect
-		if conn.Disconnected || forceReconnect {
+		// If connection is disconnected, reconnect
+		if conn.Disconnected {
 			log.Debug().
 				Str("serverID", serverID.String()).
-				Msg("Reconnecting to RCON server")
+				Msg("Reconnecting to disconnected RCON server")
 
 			// Create command connection
 			commandRcon, err := rcon.NewRcon(rcon.RconConfig{
@@ -561,6 +561,7 @@ func (m *RconManager) cleanupIdleConnections() {
 	for serverID, conn := range m.connections {
 		conn.mu.Lock()
 		if !conn.Disconnected && now.Sub(conn.LastUsed) > idleTimeout {
+			// Debug logs for idle cleanup aren't that useful in production
 			log.Info().
 				Str("serverID", serverID.String()).
 				Dur("idleTime", now.Sub(conn.LastUsed)).
@@ -625,7 +626,7 @@ func (m *RconManager) ConnectToAllServers(ctx context.Context, db *sql.DB) {
 		}
 
 		// Try to connect to the server
-		err := m.ConnectToServer(id, ipAddress, rconPort, rconPassword, false)
+		err := m.ConnectToServer(id, ipAddress, rconPort, rconPassword)
 		if err != nil {
 			log.Warn().
 				Err(err).

--- a/internal/rcon_manager/rcon_manager.go
+++ b/internal/rcon_manager/rcon_manager.go
@@ -118,12 +118,6 @@ func (m *RconManager) ConnectToServer(serverID uuid.UUID, host string, port int,
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	log.Debug().
-		Str("serverID", serverID.String()).
-		Str("host", host).
-		Int("port", port).
-		Msg("Attempting to connect to RCON server")
-
 	portStr := strconv.Itoa(port)
 
 	// Check if connection already exists

--- a/internal/rcon_manager/rcon_manager.go
+++ b/internal/rcon_manager/rcon_manager.go
@@ -1,0 +1,848 @@
+package rcon_manager
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/rs/zerolog/log"
+	"go.codycody31.dev/squad-aegis/internal/rcon"
+	squadRcon "go.codycody31.dev/squad-aegis/internal/squad-rcon"
+)
+
+// RconEvent represents an event from the RCON server
+type RconEvent struct {
+	ServerID uuid.UUID
+	Type     string
+	Data     interface{}
+	Time     time.Time
+}
+
+// RconCommand represents a command to be executed on the RCON server
+type RconCommand struct {
+	Command  string
+	Response chan CommandResponse
+}
+
+// CommandResponse represents the response from an RCON command
+type CommandResponse struct {
+	Response string
+	Error    error
+}
+
+// ServerConnection represents a connection to an RCON server
+type ServerConnection struct {
+	ServerID     uuid.UUID
+	CommandRcon  *squadRcon.SquadRcon // Connection for executing commands
+	EventRcon    *squadRcon.SquadRcon // Connection for listening to events
+	CommandChan  chan RconCommand
+	EventChan    chan RconEvent
+	Disconnected bool
+	LastUsed     time.Time
+	mu           sync.Mutex
+	cmdSemaphore chan struct{}
+	// Connection details for reconnection
+	host     string
+	port     string
+	password string
+}
+
+// RconManager manages RCON connections to multiple servers
+type RconManager struct {
+	connections      map[uuid.UUID]*ServerConnection
+	eventSubscribers []chan<- RconEvent
+	mu               sync.RWMutex
+	ctx              context.Context
+	cancel           context.CancelFunc
+}
+
+// NewRconManager creates a new RCON manager
+func NewRconManager(ctx context.Context) *RconManager {
+	ctx, cancel := context.WithCancel(ctx)
+	return &RconManager{
+		connections:      make(map[uuid.UUID]*ServerConnection),
+		eventSubscribers: []chan<- RconEvent{},
+		ctx:              ctx,
+		cancel:           cancel,
+	}
+}
+
+// SubscribeToEvents subscribes to RCON events
+func (m *RconManager) SubscribeToEvents() chan RconEvent {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	eventChan := make(chan RconEvent, 100)
+	m.eventSubscribers = append(m.eventSubscribers, eventChan)
+	return eventChan
+}
+
+// UnsubscribeFromEvents unsubscribes from RCON events
+func (m *RconManager) UnsubscribeFromEvents(eventChan chan RconEvent) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	for i, subscriber := range m.eventSubscribers {
+		if subscriber == eventChan {
+			m.eventSubscribers = append(m.eventSubscribers[:i], m.eventSubscribers[i+1:]...)
+			close(eventChan)
+			return
+		}
+	}
+}
+
+// broadcastEvent broadcasts an event to all subscribers
+func (m *RconManager) broadcastEvent(event RconEvent) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	for _, subscriber := range m.eventSubscribers {
+		select {
+		case subscriber <- event:
+		default:
+			// If channel is full, log and continue
+			log.Warn().
+				Str("serverID", event.ServerID.String()).
+				Str("eventType", event.Type).
+				Msg("Event channel full, dropping event")
+		}
+	}
+}
+
+// ConnectToServer connects to an RCON server
+func (m *RconManager) ConnectToServer(serverID uuid.UUID, host string, port int, password string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	log.Trace().
+		Str("serverID", serverID.String()).
+		Str("host", host).
+		Int("port", port).
+		Msg("Attempting to connect to RCON server")
+
+	portStr := strconv.Itoa(port)
+
+	// Check if connection already exists
+	if conn, exists := m.connections[serverID]; exists {
+		conn.mu.Lock()
+		defer conn.mu.Unlock()
+
+		// If connection is disconnected, reconnect
+		if conn.Disconnected {
+			log.Trace().
+				Str("serverID", serverID.String()).
+				Msg("Reconnecting to disconnected RCON server")
+
+			// Create command connection
+			log.Trace().
+				Str("serverID", serverID.String()).
+				Msg("Creating command RCON connection")
+			commandRcon, err := squadRcon.NewSquadRcon(rcon.RconConfig{
+				Host:               host,
+				Port:               portStr,
+				Password:           password,
+				AutoReconnect:      true,
+				AutoReconnectDelay: 5,
+			})
+			if err != nil {
+				log.Error().
+					Str("serverID", serverID.String()).
+					Err(err).
+					Msg("Failed to connect to command RCON")
+				return fmt.Errorf("failed to connect to command RCON: %w", err)
+			}
+
+			// Create event connection
+			log.Trace().
+				Str("serverID", serverID.String()).
+				Msg("Creating event RCON connection")
+			eventRcon, err := squadRcon.NewSquadRcon(rcon.RconConfig{
+				Host:               host,
+				Port:               portStr,
+				Password:           password,
+				AutoReconnect:      true,
+				AutoReconnectDelay: 5,
+			})
+			if err != nil {
+				commandRcon.Close() // Close the command connection if event connection fails
+				log.Error().
+					Str("serverID", serverID.String()).
+					Err(err).
+					Msg("Failed to connect to event RCON")
+				return fmt.Errorf("failed to connect to event RCON: %w", err)
+			}
+
+			conn.CommandRcon = commandRcon
+			conn.EventRcon = eventRcon
+			conn.Disconnected = false
+			conn.LastUsed = time.Now()
+			// Store connection details
+			conn.host = host
+			conn.port = portStr
+			conn.password = password
+
+			// Start listening for events
+			log.Trace().
+				Str("serverID", serverID.String()).
+				Msg("Starting event listener")
+			go m.listenForEvents(serverID, eventRcon)
+			// Start command processor
+			log.Trace().
+				Str("serverID", serverID.String()).
+				Msg("Starting command processor")
+			go m.processCommands(serverID, conn)
+
+			log.Info().
+				Str("serverID", serverID.String()).
+				Msg("Successfully reconnected to RCON server")
+
+			return nil
+		}
+
+		// Connection already exists and is connected
+		conn.LastUsed = time.Now()
+
+		log.Trace().
+			Str("serverID", serverID.String()).
+			Msg("RCON connection already exists and is connected")
+
+		return nil
+	}
+
+	// Create command connection
+	log.Trace().
+		Str("serverID", serverID.String()).
+		Msg("Creating new command RCON connection")
+	commandRcon, err := squadRcon.NewSquadRcon(rcon.RconConfig{
+		Host:               host,
+		Port:               portStr,
+		Password:           password,
+		AutoReconnect:      true,
+		AutoReconnectDelay: 5,
+	})
+	if err != nil {
+		log.Error().
+			Str("serverID", serverID.String()).
+			Err(err).
+			Msg("Failed to connect to command RCON")
+		return fmt.Errorf("failed to connect to command RCON: %w", err)
+	}
+
+	// Create event connection
+	log.Trace().
+		Str("serverID", serverID.String()).
+		Msg("Creating new event RCON connection")
+	eventRcon, err := squadRcon.NewSquadRcon(rcon.RconConfig{
+		Host:               host,
+		Port:               portStr,
+		Password:           password,
+		AutoReconnect:      true,
+		AutoReconnectDelay: 5,
+	})
+	if err != nil {
+		commandRcon.Close() // Close the command connection if event connection fails
+		log.Error().
+			Str("serverID", serverID.String()).
+			Err(err).
+			Msg("Failed to connect to event RCON")
+		return fmt.Errorf("failed to connect to event RCON: %w", err)
+	}
+
+	// Create a semaphore to ensure only one command executes at a time
+	cmdSemaphore := make(chan struct{}, 1)
+
+	conn := &ServerConnection{
+		ServerID:     serverID,
+		CommandRcon:  commandRcon,
+		EventRcon:    eventRcon,
+		CommandChan:  make(chan RconCommand, 100),
+		EventChan:    make(chan RconEvent, 100),
+		Disconnected: false,
+		LastUsed:     time.Now(),
+		cmdSemaphore: cmdSemaphore,
+		host:         host,
+		port:         portStr,
+		password:     password,
+	}
+
+	m.connections[serverID] = conn
+
+	// Start listening for events
+	log.Trace().
+		Str("serverID", serverID.String()).
+		Msg("Starting event listener")
+	go m.listenForEvents(serverID, eventRcon)
+	// Start command processor
+	log.Trace().
+		Str("serverID", serverID.String()).
+		Msg("Starting command processor")
+	go m.processCommands(serverID, conn)
+
+	log.Info().
+		Str("serverID", serverID.String()).
+		Msg("RCON connection created and started")
+
+	return nil
+}
+
+// DisconnectFromServer disconnects from an RCON server
+func (m *RconManager) DisconnectFromServer(serverID uuid.UUID) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	conn, exists := m.connections[serverID]
+	if !exists {
+		return errors.New("server not connected")
+	}
+
+	conn.mu.Lock()
+	defer conn.mu.Unlock()
+
+	if conn.Disconnected {
+		return errors.New("server already disconnected")
+	}
+
+	// Close both connections
+	conn.CommandRcon.Close()
+	conn.EventRcon.Close()
+	conn.Disconnected = true
+
+	return nil
+}
+
+// ExecuteCommand executes a command on an RCON server
+func (m *RconManager) ExecuteCommand(serverID uuid.UUID, command string) (string, error) {
+	m.mu.RLock()
+	conn, exists := m.connections[serverID]
+	m.mu.RUnlock()
+
+	if !exists {
+		log.Error().
+			Str("serverID", serverID.String()).
+			Str("command", command).
+			Msg("Server not connected")
+		return "", errors.New("server not connected")
+	}
+
+	conn.mu.Lock()
+	if conn.Disconnected {
+		conn.mu.Unlock()
+		log.Error().
+			Str("serverID", serverID.String()).
+			Str("command", command).
+			Msg("Server disconnected")
+		return "", errors.New("server disconnected")
+	}
+	conn.LastUsed = time.Now()
+	conn.mu.Unlock()
+
+	log.Trace().
+		Str("serverID", serverID.String()).
+		Str("command", command).
+		Msg("Queueing RCON command")
+
+	// Create response channel
+	responseChan := make(chan CommandResponse, 1)
+
+	// Send command to command processor
+	select {
+	case conn.CommandChan <- RconCommand{Command: command, Response: responseChan}:
+		log.Trace().
+			Str("serverID", serverID.String()).
+			Str("command", command).
+			Msg("Command queued successfully")
+	case <-time.After(5 * time.Second):
+		log.Error().
+			Str("serverID", serverID.String()).
+			Str("command", command).
+			Msg("Command queue full, try again later")
+		return "", errors.New("command queue full, try again later")
+	}
+
+	log.Trace().
+		Str("serverID", serverID.String()).
+		Str("command", command).
+		Msg("Waiting for command response")
+
+	// Wait for response
+	select {
+	case response := <-responseChan:
+		if response.Error != nil {
+			log.Debug().
+				Str("serverID", serverID.String()).
+				Str("command", command).
+				Err(response.Error).
+				Msg("Command execution failed")
+		} else {
+			log.Trace().
+				Str("serverID", serverID.String()).
+				Str("command", command).
+				Int("responseLength", len(response.Response)).
+				Msg("Command executed successfully")
+		}
+		return response.Response, response.Error
+	case <-time.After(30 * time.Second):
+		log.Error().
+			Str("serverID", serverID.String()).
+			Str("command", command).
+			Msg("Command timed out")
+		return "", errors.New("command timed out")
+	}
+}
+
+// processCommands processes commands for a server
+func (m *RconManager) processCommands(serverID uuid.UUID, conn *ServerConnection) {
+	log.Trace().
+		Str("serverID", serverID.String()).
+		Msg("Starting command processor")
+
+	for {
+		select {
+		case cmd := <-conn.CommandChan:
+			// Process the command directly in the main goroutine
+			// This ensures sequential processing without potential deadlocks
+
+			log.Trace().
+				Str("serverID", serverID.String()).
+				Str("command", cmd.Command).
+				Msg("Received command from queue")
+
+			// Acquire the semaphore
+			log.Trace().
+				Str("serverID", serverID.String()).
+				Str("command", cmd.Command).
+				Msg("Acquiring command semaphore")
+			conn.cmdSemaphore <- struct{}{}
+			log.Trace().
+				Str("serverID", serverID.String()).
+				Str("command", cmd.Command).
+				Msg("Acquired command semaphore")
+
+			// Check connection status
+			conn.mu.Lock()
+			if conn.Disconnected {
+				conn.mu.Unlock()
+				log.Debug().
+					Str("serverID", serverID.String()).
+					Str("command", cmd.Command).
+					Msg("Server disconnected, cannot execute command")
+				cmd.Response <- CommandResponse{
+					Response: "",
+					Error:    errors.New("server disconnected"),
+				}
+				// Release the semaphore
+				<-conn.cmdSemaphore
+				log.Trace().
+					Str("serverID", serverID.String()).
+					Str("command", cmd.Command).
+					Msg("Released command semaphore after disconnection")
+				continue
+			}
+
+			// FIXME: Workaround for Buffer Overflow causing the connection to crash
+			// Check if we need to recreate the command connection
+			// This ensures each command gets a fresh connection state
+			if cmd.Command != "PING_CONNECTION" {
+				log.Trace().
+					Str("serverID", serverID.String()).
+					Str("command", cmd.Command).
+					Msg("Recreating command connection for fresh state")
+
+				// Close the old connection
+				conn.CommandRcon.Close()
+
+				// Create a new connection using stored connection details
+				newCommandRcon, err := squadRcon.NewSquadRcon(rcon.RconConfig{
+					Host:               conn.host,
+					Port:               conn.port,
+					Password:           conn.password,
+					AutoReconnect:      true,
+					AutoReconnectDelay: 5,
+				})
+
+				if err != nil {
+					conn.mu.Unlock()
+					log.Error().
+						Str("serverID", serverID.String()).
+						Str("command", cmd.Command).
+						Err(err).
+						Msg("Failed to recreate command connection")
+
+					cmd.Response <- CommandResponse{
+						Response: "",
+						Error:    fmt.Errorf("failed to recreate command connection: %w", err),
+					}
+
+					// Release the semaphore
+					<-conn.cmdSemaphore
+					continue
+				}
+
+				// Update the connection
+				conn.CommandRcon = newCommandRcon
+				log.Trace().
+					Str("serverID", serverID.String()).
+					Str("command", cmd.Command).
+					Msg("Command connection recreated successfully")
+			}
+
+			conn.LastUsed = time.Now()
+			conn.mu.Unlock()
+
+			// Execute command with timeout
+			responseChan := make(chan CommandResponse, 1)
+
+			log.Trace().
+				Str("serverID", serverID.String()).
+				Str("command", cmd.Command).
+				Msg("Executing command")
+
+			startTime := time.Now()
+			go func() {
+				// Execute command using the command connection
+				log.Trace().
+					Str("serverID", serverID.String()).
+					Str("command", cmd.Command).
+					Msg("Sending command to RCON server")
+				response, err := conn.CommandRcon.Rcon.Execute(cmd.Command)
+				execTime := time.Since(startTime)
+				if err != nil {
+					log.Debug().
+						Str("serverID", serverID.String()).
+						Str("command", cmd.Command).
+						Err(err).
+						Dur("execTime", execTime).
+						Msg("Command execution returned error")
+				} else {
+					log.Trace().
+						Str("serverID", serverID.String()).
+						Str("command", cmd.Command).
+						Int("responseLength", len(response)).
+						Dur("execTime", execTime).
+						Msg("Command execution completed")
+				}
+				select {
+				case responseChan <- CommandResponse{
+					Response: response,
+					Error:    err,
+				}:
+					log.Trace().
+						Str("serverID", serverID.String()).
+						Str("command", cmd.Command).
+						Msg("Response sent to channel")
+				default:
+					// Channel might be closed if timeout occurred
+					log.Debug().
+						Str("serverID", serverID.String()).
+						Str("command", cmd.Command).
+						Msg("Could not send response to channel, might be closed")
+				}
+			}()
+
+			// Wait for response with timeout
+			log.Trace().
+				Str("serverID", serverID.String()).
+				Str("command", cmd.Command).
+				Msg("Waiting for command response with timeout")
+			var cmdResponse CommandResponse
+			select {
+			case response := <-responseChan:
+				cmdResponse = response
+				log.Trace().
+					Str("serverID", serverID.String()).
+					Str("command", cmd.Command).
+					Msg("Received command response")
+			case <-time.After(25 * time.Second): // Slightly less than the client timeout
+				cmdResponse = CommandResponse{
+					Response: "",
+					Error:    errors.New("command execution timed out"),
+				}
+				log.Debug().
+					Str("serverID", serverID.String()).
+					Str("command", cmd.Command).
+					Msg("Command execution timed out internally")
+			}
+
+			// Send response back to caller
+			log.Trace().
+				Str("serverID", serverID.String()).
+				Str("command", cmd.Command).
+				Msg("Sending response back to caller")
+			cmd.Response <- cmdResponse
+
+			// Release the semaphore
+			log.Trace().
+				Str("serverID", serverID.String()).
+				Str("command", cmd.Command).
+				Msg("Releasing command semaphore")
+			<-conn.cmdSemaphore
+			log.Trace().
+				Str("serverID", serverID.String()).
+				Str("command", cmd.Command).
+				Msg("Released command semaphore")
+
+			// Log command execution
+			if cmdResponse.Error != nil {
+				log.Debug().
+					Str("serverID", serverID.String()).
+					Str("command", cmd.Command).
+					Err(cmdResponse.Error).
+					Msg("RCON command execution failed")
+			} else {
+				log.Trace().
+					Str("serverID", serverID.String()).
+					Str("command", cmd.Command).
+					Int("responseLength", len(cmdResponse.Response)).
+					Msg("RCON command executed successfully")
+			}
+
+		case <-m.ctx.Done():
+			log.Trace().
+				Str("serverID", serverID.String()).
+				Msg("Stopping command processor due to context cancellation")
+			return
+		}
+	}
+}
+
+// listenForEvents listens for events from an RCON server
+func (m *RconManager) listenForEvents(serverID uuid.UUID, sr *squadRcon.SquadRcon) {
+	// Setup event listeners
+	sr.Rcon.Emitter.On("CHAT_MESSAGE", func(data interface{}) {
+		event := RconEvent{
+			ServerID: serverID,
+			Type:     "CHAT_MESSAGE",
+			Data:     data,
+			Time:     time.Now(),
+		}
+
+		m.broadcastEvent(event)
+	})
+
+	sr.Rcon.Emitter.On("PLAYER_WARNED", func(data interface{}) {
+		event := RconEvent{
+			ServerID: serverID,
+			Type:     "PLAYER_WARNED",
+			Data:     data,
+			Time:     time.Now(),
+		}
+
+		m.broadcastEvent(event)
+	})
+
+	sr.Rcon.Emitter.On("PLAYER_KICKED", func(data interface{}) {
+		event := RconEvent{
+			ServerID: serverID,
+			Type:     "PLAYER_KICKED",
+			Data:     data,
+			Time:     time.Now(),
+		}
+
+		m.broadcastEvent(event)
+	})
+
+	sr.Rcon.Emitter.On("POSSESSED_ADMIN_CAMERA", func(data interface{}) {
+		event := RconEvent{
+			ServerID: serverID,
+			Type:     "POSSESSED_ADMIN_CAMERA",
+			Data:     data,
+			Time:     time.Now(),
+		}
+
+		m.broadcastEvent(event)
+	})
+
+	sr.Rcon.Emitter.On("UNPOSSESSED_ADMIN_CAMERA", func(data interface{}) {
+		event := RconEvent{
+			ServerID: serverID,
+			Type:     "UNPOSSESSED_ADMIN_CAMERA",
+			Data:     data,
+			Time:     time.Now(),
+		}
+
+		m.broadcastEvent(event)
+	})
+
+	sr.Rcon.Emitter.On("SQUAD_CREATED", func(data interface{}) {
+		event := RconEvent{
+			ServerID: serverID,
+			Type:     "SQUAD_CREATED",
+			Data:     data,
+			Time:     time.Now(),
+		}
+
+		m.broadcastEvent(event)
+	})
+
+	// Listen for connection events
+	sr.Rcon.Emitter.On("close", func(data interface{}) {
+		event := RconEvent{
+			ServerID: serverID,
+			Type:     "CONNECTION_CLOSED",
+			Data:     nil,
+			Time:     time.Now(),
+		}
+
+		m.broadcastEvent(event)
+	})
+
+	sr.Rcon.Emitter.On("error", func(data interface{}) {
+		event := RconEvent{
+			ServerID: serverID,
+			Type:     "CONNECTION_ERROR",
+			Data:     data,
+			Time:     time.Now(),
+		}
+
+		m.broadcastEvent(event)
+	})
+
+	// Block until context is done
+	<-m.ctx.Done()
+}
+
+// StartConnectionManager starts the connection manager
+func (m *RconManager) StartConnectionManager() {
+	ticker := time.NewTicker(5 * time.Minute)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			m.cleanupIdleConnections()
+		case <-m.ctx.Done():
+			m.cleanupAllConnections()
+			return
+		}
+	}
+}
+
+// cleanupIdleConnections closes idle connections
+func (m *RconManager) cleanupIdleConnections() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	now := time.Now()
+	idleTimeout := 30 * time.Minute
+
+	for serverID, conn := range m.connections {
+		conn.mu.Lock()
+		if !conn.Disconnected && now.Sub(conn.LastUsed) > idleTimeout {
+			log.Trace().
+				Str("serverID", serverID.String()).
+				Msg("Closing idle RCON connection")
+
+			conn.CommandRcon.Close()
+			conn.EventRcon.Close()
+			conn.Disconnected = true
+		}
+		conn.mu.Unlock()
+	}
+}
+
+// cleanupAllConnections closes all connections
+func (m *RconManager) cleanupAllConnections() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	for serverID, conn := range m.connections {
+		conn.mu.Lock()
+		if !conn.Disconnected {
+			log.Trace().
+				Str("serverID", serverID.String()).
+				Msg("Closing RCON connections during shutdown")
+
+			conn.CommandRcon.Close()
+			conn.EventRcon.Close()
+			conn.Disconnected = true
+		}
+		conn.mu.Unlock()
+	}
+}
+
+// Shutdown shuts down the RCON manager
+func (m *RconManager) Shutdown() {
+	m.cancel()
+}
+
+// ConnectToAllServers connects to all servers in the database
+func (m *RconManager) ConnectToAllServers(ctx context.Context, db *sql.DB) {
+	// Get all servers from the database
+	rows, err := db.QueryContext(ctx, `
+		SELECT id, ip_address, rcon_port, rcon_password
+		FROM servers
+		WHERE rcon_port > 0 AND rcon_password != ''
+	`)
+	if err != nil {
+		log.Error().Err(err).Msg("Failed to query servers for RCON connections")
+		return
+	}
+	defer rows.Close()
+
+	// Connect to each server
+	for rows.Next() {
+		var id uuid.UUID
+		var ipAddress string
+		var rconPort int
+		var rconPassword string
+
+		if err := rows.Scan(&id, &ipAddress, &rconPort, &rconPassword); err != nil {
+			log.Error().Err(err).Msg("Failed to scan server row")
+			continue
+		}
+
+		// Try to connect to the server
+		err := m.ConnectToServer(id, ipAddress, rconPort, rconPassword)
+		if err != nil {
+			log.Warn().
+				Err(err).
+				Str("serverID", id.String()).
+				Str("ipAddress", ipAddress).
+				Int("rconPort", rconPort).
+				Msg("Failed to connect to server RCON")
+			continue
+		}
+
+		log.Info().
+			Str("serverID", id.String()).
+			Str("ipAddress", ipAddress).
+			Int("rconPort", rconPort).
+			Msg("Connected to server RCON")
+	}
+
+	if err := rows.Err(); err != nil {
+		log.Error().Err(err).Msg("Error iterating server rows")
+	}
+}
+
+// ProcessChatMessages starts processing chat messages for all connected servers
+func (m *RconManager) ProcessChatMessages(ctx context.Context, messageHandler func(serverID uuid.UUID, message rcon.Message)) {
+	// Create a channel to receive chat events
+	eventChan := m.SubscribeToEvents()
+
+	// Start a goroutine to process events
+	go func() {
+		defer m.UnsubscribeFromEvents(eventChan)
+
+		for {
+			select {
+			case <-ctx.Done():
+				log.Info().Msg("Stopping chat message processor")
+				return
+			case event := <-eventChan:
+				// Only process chat messages
+				if event.Type == "CHAT_MESSAGE" {
+					if message, ok := event.Data.(rcon.Message); ok {
+						// Call the message handler
+						messageHandler(event.ServerID, message)
+					}
+				}
+			}
+		}
+	}()
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -132,7 +132,6 @@ func NewRouter(serverDependencies *Dependencies) *gin.Engine {
 				serverGroup.GET("/status", server.ServerStatus)
 				serverGroup.GET("/audit-logs", server.AuthHasServerPermission("manageserver"), server.ServerAuditLogs)
 
-				serverGroup.POST("/rcon/reconnect", server.AuthHasServerPermission("manageserver"), server.ServerRconReconnect)
 				serverGroup.GET("/rcon/commands", server.RconCommandList)
 				serverGroup.GET("/rcon/commands/autocomplete", server.RconCommandAutocomplete)
 				serverGroup.POST("/rcon/execute", server.AuthHasServerPermission("manageserver"), server.ServerRconExecute)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -132,6 +132,7 @@ func NewRouter(serverDependencies *Dependencies) *gin.Engine {
 				serverGroup.GET("/status", server.ServerStatus)
 				serverGroup.GET("/audit-logs", server.AuthHasServerPermission("manageserver"), server.ServerAuditLogs)
 
+				serverGroup.POST("/rcon/reconnect", server.AuthHasServerPermission("manageserver"), server.ServerRconReconnect)
 				serverGroup.GET("/rcon/commands", server.RconCommandList)
 				serverGroup.GET("/rcon/commands/autocomplete", server.RconCommandAutocomplete)
 				serverGroup.POST("/rcon/execute", server.AuthHasServerPermission("manageserver"), server.ServerRconExecute)

--- a/internal/server/servers.go
+++ b/internal/server/servers.go
@@ -157,6 +157,9 @@ func (s *Server) ServersCreate(c *gin.Context) {
 		return
 	}
 
+	// Connect to RCON
+	_ = s.Dependencies.RconManager.ConnectToServer(server.Id, server.IpAddress, server.RconPort, server.RconPassword)
+
 	responses.Success(c, "Server created successfully", &gin.H{"server": server})
 }
 

--- a/internal/server/servers_bans.go
+++ b/internal/server/servers_bans.go
@@ -151,11 +151,8 @@ func (s *Server) ServerBansAdd(c *gin.Context) {
 
 	// Also apply the ban via RCON if the server is online
 	if server != nil {
-		r, err := squadRcon.NewSquadRcon(rcon.RconConfig{Host: server.IpAddress, Password: server.RconPassword, Port: strconv.Itoa(server.RconPort), AutoReconnect: true, AutoReconnectDelay: 5})
-		if err == nil {
-			defer r.Close()
-			_ = r.BanPlayer(request.SteamID, request.Duration, request.Reason)
-		}
+		r := squadRcon.NewSquadRcon(s.Dependencies.RconManager, server.Id)
+		_ = r.BanPlayer(request.SteamID, request.Duration, request.Reason)
 	}
 
 	// Create detailed audit log

--- a/internal/server/servers_rcon.go
+++ b/internal/server/servers_rcon.go
@@ -26,32 +26,6 @@ type MovePlayerRequest struct {
 	SteamId string `json:"steamId" binding:"required"`
 }
 
-// ServerRconReconnect handles the reconnecting of a server to RCON
-func (s *Server) ServerRconReconnect(c *gin.Context) {
-	user := s.getUserFromSession(c)
-
-	serverIdString := c.Param("serverId")
-	serverId, err := uuid.Parse(serverIdString)
-	if err != nil {
-		responses.BadRequest(c, "Invalid server ID", &gin.H{"error": err.Error()})
-		return
-	}
-
-	server, err := core.GetServerById(c.Request.Context(), s.Dependencies.DB, serverId, user)
-	if err != nil {
-		responses.BadRequest(c, "Failed to get server", &gin.H{"error": err.Error()})
-		return
-	}
-
-	err = s.Dependencies.RconManager.ConnectToServer(serverId, server.IpAddress, server.RconPort, server.RconPassword, true)
-	if err != nil {
-		responses.BadRequest(c, "Failed to connect to RCON", &gin.H{"error": err.Error()})
-		return
-	}
-
-	responses.Success(c, "RCON connected successfully", &gin.H{"response": "RCON connected successfully"})
-}
-
 // RconCommandList handles the listing of all commands that can be executed by the server
 func (s *Server) RconCommandList(c *gin.Context) {
 	var commandsList []commands.CommandInfo
@@ -109,7 +83,7 @@ func (s *Server) ServerRconExecute(c *gin.Context) {
 	}
 
 	// Ensure server is connected to RCON manager
-	err = s.Dependencies.RconManager.ConnectToServer(serverId, server.IpAddress, server.RconPort, server.RconPassword, false)
+	err = s.Dependencies.RconManager.ConnectToServer(serverId, server.IpAddress, server.RconPort, server.RconPassword)
 	if err != nil {
 		responses.BadRequest(c, "Failed to connect to RCON", &gin.H{"error": err.Error()})
 		return

--- a/internal/server/servers_rcon_events.go
+++ b/internal/server/servers_rcon_events.go
@@ -1,0 +1,95 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"go.codycody31.dev/squad-aegis/core"
+	"go.codycody31.dev/squad-aegis/internal/server/responses"
+)
+
+// ServerRconEvents handles subscribing to RCON events using Server-Sent Events (SSE)
+func (s *Server) ServerRconEvents(c *gin.Context) {
+	user := s.getUserFromSession(c)
+
+	serverIdString := c.Param("serverId")
+	serverId, err := uuid.Parse(serverIdString)
+	if err != nil {
+		responses.BadRequest(c, "Invalid server ID", &gin.H{"error": err.Error()})
+		return
+	}
+
+	server, err := core.GetServerById(c.Request.Context(), s.Dependencies.DB, serverId, user)
+	if err != nil {
+		responses.BadRequest(c, "Failed to get server", &gin.H{"error": err.Error()})
+		return
+	}
+
+	// Ensure server is connected to RCON manager
+	err = s.Dependencies.RconManager.ConnectToServer(serverId, server.IpAddress, server.RconPort, server.RconPassword)
+	if err != nil {
+		responses.BadRequest(c, "Failed to connect to RCON", &gin.H{"error": err.Error()})
+		return
+	}
+
+	// Subscribe to RCON events
+	eventChan := s.Dependencies.RconManager.SubscribeToEvents()
+	defer s.Dependencies.RconManager.UnsubscribeFromEvents(eventChan)
+
+	// Set headers for SSE
+	c.Writer.Header().Set("Content-Type", "text/event-stream")
+	c.Writer.Header().Set("Cache-Control", "no-cache")
+	c.Writer.Header().Set("Connection", "keep-alive")
+	c.Writer.Header().Set("Transfer-Encoding", "chunked")
+	c.Writer.Flush()
+
+	// Create a context that is canceled when the client disconnects
+	ctx, cancel := context.WithCancel(c.Request.Context())
+	defer cancel()
+
+	// Create a goroutine to detect client disconnection
+	go func() {
+		<-c.Request.Context().Done()
+		cancel()
+	}()
+
+	// Send a ping event every 30 seconds to keep the connection alive
+	ticker := time.NewTicker(30 * time.Second)
+	defer ticker.Stop()
+
+	// Create audit log for connection
+	s.CreateAuditLog(c.Request.Context(), &serverId, &user.Id, "server:rcon:events:connect", nil)
+
+	// Send events to client
+	for {
+		select {
+		case <-ctx.Done():
+			// Client disconnected
+			s.CreateAuditLog(c.Request.Context(), &serverId, &user.Id, "server:rcon:events:disconnect", nil)
+			return
+		case event := <-eventChan:
+			// Only send events for this server
+			if event.ServerID != serverId {
+				continue
+			}
+
+			// Convert event to JSON
+			eventJSON, err := json.Marshal(event)
+			if err != nil {
+				continue
+			}
+
+			// Send event to client
+			fmt.Fprintf(c.Writer, "data: %s\n\n", eventJSON)
+			c.Writer.Flush()
+		case <-ticker.C:
+			// Send ping event
+			fmt.Fprintf(c.Writer, "event: ping\ndata: %d\n\n", time.Now().Unix())
+			c.Writer.Flush()
+		}
+	}
+}

--- a/internal/server/servers_rcon_events.go
+++ b/internal/server/servers_rcon_events.go
@@ -30,7 +30,7 @@ func (s *Server) ServerRconEvents(c *gin.Context) {
 	}
 
 	// Ensure server is connected to RCON manager
-	err = s.Dependencies.RconManager.ConnectToServer(serverId, server.IpAddress, server.RconPort, server.RconPassword, false)
+	err = s.Dependencies.RconManager.ConnectToServer(serverId, server.IpAddress, server.RconPort, server.RconPassword)
 	if err != nil {
 		responses.BadRequest(c, "Failed to connect to RCON", &gin.H{"error": err.Error()})
 		return

--- a/internal/server/servers_rcon_events.go
+++ b/internal/server/servers_rcon_events.go
@@ -30,7 +30,7 @@ func (s *Server) ServerRconEvents(c *gin.Context) {
 	}
 
 	// Ensure server is connected to RCON manager
-	err = s.Dependencies.RconManager.ConnectToServer(serverId, server.IpAddress, server.RconPort, server.RconPassword)
+	err = s.Dependencies.RconManager.ConnectToServer(serverId, server.IpAddress, server.RconPort, server.RconPassword, false)
 	if err != nil {
 		responses.BadRequest(c, "Failed to connect to RCON", &gin.H{"error": err.Error()})
 		return

--- a/internal/squad-rcon/squad-rcon.go
+++ b/internal/squad-rcon/squad-rcon.go
@@ -8,7 +8,8 @@ import (
 	"strconv"
 	"strings"
 
-	"go.codycody31.dev/squad-aegis/internal/rcon"
+	"github.com/google/uuid"
+	"go.codycody31.dev/squad-aegis/internal/rcon_manager"
 )
 
 var (
@@ -17,7 +18,9 @@ var (
 )
 
 type SquadRcon struct {
-	Rcon *rcon.Rcon
+	// Replace direct Rcon reference with RconManager and serverID
+	Manager  *rcon_manager.RconManager
+	ServerID uuid.UUID
 }
 
 // Player represents a player in the game
@@ -291,24 +294,37 @@ type PlayersData struct {
 	DisconnectedPlayers []Player `json:"disconnectedPlayers"`
 }
 
-func NewSquadRcon(rconConfig rcon.RconConfig) (*SquadRcon, error) {
-	rcon, err := rcon.NewRcon(rconConfig)
+// NewSquadRcon creates a new SquadRcon instance using RconManager
+func NewSquadRcon(manager *rcon_manager.RconManager, serverID uuid.UUID) *SquadRcon {
+	return &SquadRcon{
+		Manager:  manager,
+		ServerID: serverID,
+	}
+}
+
+// NewSquadRconWithConnection creates a new SquadRcon instance and connects to the server using RconManager
+func NewSquadRconWithConnection(manager *rcon_manager.RconManager, serverID uuid.UUID, host string, port int, password string) (*SquadRcon, error) {
+	// Connect to the server using RconManager
+	err := manager.ConnectToServer(serverID, host, port, password)
 	if err != nil {
 		return nil, err
 	}
 
-	return &SquadRcon{Rcon: rcon}, nil
+	return &SquadRcon{
+		Manager:  manager,
+		ServerID: serverID,
+	}, nil
 }
 
 // BanPlayer bans a player from the server
 func (s *SquadRcon) BanPlayer(steamId string, duration int, reason string) error {
-	_, err := s.Rcon.Execute(fmt.Sprintf("AdminBan %s %dd %s", steamId, duration, reason))
+	_, err := s.Manager.ExecuteCommand(s.ServerID, fmt.Sprintf("AdminBan %s %dd %s", steamId, duration, reason))
 	return err
 }
 
 // GetServerPlayers gets the online and disconnected players from the server
 func (s *SquadRcon) GetServerPlayers() (PlayersData, error) {
-	playersResponse, err := s.Rcon.Execute("ListPlayers")
+	playersResponse, err := s.Manager.ExecuteCommand(s.ServerID, "ListPlayers")
 	if err != nil {
 		return PlayersData{}, err
 	}
@@ -363,7 +379,7 @@ func (s *SquadRcon) GetServerPlayers() (PlayersData, error) {
 }
 
 func (s *SquadRcon) GetServerSquads() ([]Squad, []string, error) {
-	squadsResponse, err := s.Rcon.Execute("ListSquads")
+	squadsResponse, err := s.Manager.ExecuteCommand(s.ServerID, "ListSquads")
 	if err != nil {
 		return []Squad{}, []string{}, err
 	}
@@ -410,7 +426,7 @@ func (s *SquadRcon) GetServerSquads() ([]Squad, []string, error) {
 }
 
 func (s *SquadRcon) GetCurrentMap() (Map, error) {
-	currentMap, err := s.Rcon.Execute("ShowCurrentMap")
+	currentMap, err := s.Manager.ExecuteCommand(s.ServerID, "ShowCurrentMap")
 	if err != nil {
 		return Map{}, err
 	}
@@ -429,7 +445,7 @@ func (s *SquadRcon) GetCurrentMap() (Map, error) {
 }
 
 func (s *SquadRcon) GetNextMap() (Map, error) {
-	nextMap, err := s.Rcon.Execute("ShowNextMap")
+	nextMap, err := s.Manager.ExecuteCommand(s.ServerID, "ShowNextMap")
 	if err != nil {
 		if nextMap == "Next level is not defined" {
 			return Map{}, ErrNoNextMap
@@ -453,7 +469,7 @@ func (s *SquadRcon) GetNextMap() (Map, error) {
 
 // GetAvailableMaps gets the available maps from the server
 func (s *SquadRcon) GetAvailableLayers() ([]Layer, error) {
-	availableLayers, err := s.Rcon.Execute("ListLayers")
+	availableLayers, err := s.Manager.ExecuteCommand(s.ServerID, "ListLayers")
 	if err != nil {
 		return []Layer{}, err
 	}
@@ -483,7 +499,7 @@ func (s *SquadRcon) GetAvailableLayers() ([]Layer, error) {
 
 // GetServerInfo gets the server info from the server
 func (s *SquadRcon) GetServerInfo() (ServerInfo, error) {
-	serverInfo, err := s.Rcon.Execute("ShowServerInfo")
+	serverInfo, err := s.Manager.ExecuteCommand(s.ServerID, "ShowServerInfo")
 	if err != nil {
 		return ServerInfo{}, err
 	}
@@ -575,6 +591,13 @@ func (s *SquadRcon) GetTeamsAndSquads() ([]Team, error) {
 	return ParseTeamsAndSquads(squads, teamNames, players)
 }
 
+// Close method is no longer needed as RconManager handles connections
+// But we'll keep a no-op version for API compatibility
 func (s *SquadRcon) Close() {
-	s.Rcon.Close()
+	// No-op - connection management is handled by RconManager
+}
+
+// ExecuteRaw allows executing raw RCON commands directly
+func (s *SquadRcon) ExecuteRaw(command string) (string, error) {
+	return s.Manager.ExecuteCommand(s.ServerID, command)
 }

--- a/internal/squad-rcon/squad-rcon.go
+++ b/internal/squad-rcon/squad-rcon.go
@@ -305,7 +305,7 @@ func NewSquadRcon(manager *rcon_manager.RconManager, serverID uuid.UUID) *SquadR
 // NewSquadRconWithConnection creates a new SquadRcon instance and connects to the server using RconManager
 func NewSquadRconWithConnection(manager *rcon_manager.RconManager, serverID uuid.UUID, host string, port int, password string) (*SquadRcon, error) {
 	// Connect to the server using RconManager
-	err := manager.ConnectToServer(serverID, host, port, password, false)
+	err := manager.ConnectToServer(serverID, host, port, password)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/squad-rcon/squad-rcon.go
+++ b/internal/squad-rcon/squad-rcon.go
@@ -305,7 +305,7 @@ func NewSquadRcon(manager *rcon_manager.RconManager, serverID uuid.UUID) *SquadR
 // NewSquadRconWithConnection creates a new SquadRcon instance and connects to the server using RconManager
 func NewSquadRconWithConnection(manager *rcon_manager.RconManager, serverID uuid.UUID, host string, port int, password string) (*SquadRcon, error) {
 	// Connect to the server using RconManager
-	err := manager.ConnectToServer(serverID, host, port, password)
+	err := manager.ConnectToServer(serverID, host, port, password, false)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/squad-rcon/squad-rcon.go
+++ b/internal/squad-rcon/squad-rcon.go
@@ -17,7 +17,7 @@ var (
 )
 
 type SquadRcon struct {
-	rcon *rcon.Rcon
+	Rcon *rcon.Rcon
 }
 
 // Player represents a player in the game
@@ -297,18 +297,18 @@ func NewSquadRcon(rconConfig rcon.RconConfig) (*SquadRcon, error) {
 		return nil, err
 	}
 
-	return &SquadRcon{rcon: rcon}, nil
+	return &SquadRcon{Rcon: rcon}, nil
 }
 
 // BanPlayer bans a player from the server
 func (s *SquadRcon) BanPlayer(steamId string, duration int, reason string) error {
-	_, err := s.rcon.Execute(fmt.Sprintf("AdminBan %s %dd %s", steamId, duration, reason))
+	_, err := s.Rcon.Execute(fmt.Sprintf("AdminBan %s %dd %s", steamId, duration, reason))
 	return err
 }
 
 // GetServerPlayers gets the online and disconnected players from the server
 func (s *SquadRcon) GetServerPlayers() (PlayersData, error) {
-	playersResponse, err := s.rcon.Execute("ListPlayers")
+	playersResponse, err := s.Rcon.Execute("ListPlayers")
 	if err != nil {
 		return PlayersData{}, err
 	}
@@ -363,7 +363,7 @@ func (s *SquadRcon) GetServerPlayers() (PlayersData, error) {
 }
 
 func (s *SquadRcon) GetServerSquads() ([]Squad, []string, error) {
-	squadsResponse, err := s.rcon.Execute("ListSquads")
+	squadsResponse, err := s.Rcon.Execute("ListSquads")
 	if err != nil {
 		return []Squad{}, []string{}, err
 	}
@@ -410,7 +410,7 @@ func (s *SquadRcon) GetServerSquads() ([]Squad, []string, error) {
 }
 
 func (s *SquadRcon) GetCurrentMap() (Map, error) {
-	currentMap, err := s.rcon.Execute("ShowCurrentMap")
+	currentMap, err := s.Rcon.Execute("ShowCurrentMap")
 	if err != nil {
 		return Map{}, err
 	}
@@ -429,7 +429,7 @@ func (s *SquadRcon) GetCurrentMap() (Map, error) {
 }
 
 func (s *SquadRcon) GetNextMap() (Map, error) {
-	nextMap, err := s.rcon.Execute("ShowNextMap")
+	nextMap, err := s.Rcon.Execute("ShowNextMap")
 	if err != nil {
 		if nextMap == "Next level is not defined" {
 			return Map{}, ErrNoNextMap
@@ -453,7 +453,7 @@ func (s *SquadRcon) GetNextMap() (Map, error) {
 
 // GetAvailableMaps gets the available maps from the server
 func (s *SquadRcon) GetAvailableLayers() ([]Layer, error) {
-	availableLayers, err := s.rcon.Execute("ListLayers")
+	availableLayers, err := s.Rcon.Execute("ListLayers")
 	if err != nil {
 		return []Layer{}, err
 	}
@@ -483,7 +483,7 @@ func (s *SquadRcon) GetAvailableLayers() ([]Layer, error) {
 
 // GetServerInfo gets the server info from the server
 func (s *SquadRcon) GetServerInfo() (ServerInfo, error) {
-	serverInfo, err := s.rcon.Execute("ShowServerInfo")
+	serverInfo, err := s.Rcon.Execute("ShowServerInfo")
 	if err != nil {
 		return ServerInfo{}, err
 	}
@@ -576,5 +576,5 @@ func (s *SquadRcon) GetTeamsAndSquads() ([]Team, error) {
 }
 
 func (s *SquadRcon) Close() {
-	s.rcon.Close()
+	s.Rcon.Close()
 }

--- a/shared/config/struct.go
+++ b/shared/config/struct.go
@@ -26,8 +26,9 @@ type Struct struct {
 		}
 	}
 	Log struct {
-		Level string `default:"info"`
-		File  string `default:""`
+		Level   string `default:"info"`
+		ShowGin bool   `default:"false"`
+		File    string `default:""`
 	}
 	Debug struct {
 		Pretty  bool `default:"true"`

--- a/web/pages/servers/[serverId]/connected-players.vue
+++ b/web/pages/servers/[serverId]/connected-players.vue
@@ -244,7 +244,6 @@ function openActionDialog(player: Player, action: 'kick' | 'ban' | 'warn' | 'mov
   actionType.value = action;
   actionReason.value = "";
   actionDuration.value = action === 'ban' ? "1" : "";
-  targetTeamId.value = action === 'move' ? (availableTeams.value.length > 0 ? availableTeams.value[0].id : null) : null;
   showActionDialog.value = true;
 }
 
@@ -542,19 +541,19 @@ async function executePlayerAction() {
                         </Button>
                       </DropdownMenuTrigger>
                       <DropdownMenuContent align="end">
-                        <DropdownMenuItem @click="openActionDialog(player, 'warn')" v-if="authStore.getServerPermissions(serverId as string).includes('kick')">
+                        <DropdownMenuItem @click="openActionDialog(player, 'warn')" v-if="authStore.getServerPermission(serverId as string, 'warn')">
                           <Icon name="lucide:alert-triangle" class="mr-2 h-4 w-4 text-yellow-500" />
                           <span>Warn Player</span>
                         </DropdownMenuItem>
-                        <DropdownMenuItem @click="openActionDialog(player, 'move')" v-if="authStore.getServerPermissions(serverId as string).includes('forceteamchange')">
+                        <DropdownMenuItem @click="openActionDialog(player, 'move')" v-if="authStore.getServerPermission(serverId as string, 'forceteamchange')">
                           <Icon name="lucide:move" class="mr-2 h-4 w-4 text-blue-500" />
                           <span>Move to Other Team</span>
                         </DropdownMenuItem>
-                        <DropdownMenuItem @click="openActionDialog(player, 'kick')" v-if="authStore.getServerPermissions(serverId as string).includes('kick')">
+                        <DropdownMenuItem @click="openActionDialog(player, 'kick')" v-if="authStore.getServerPermission(serverId as string, 'kick')">
                           <Icon name="lucide:log-out" class="mr-2 h-4 w-4 text-orange-500" />
                           <span>Kick Player</span>
                         </DropdownMenuItem>
-                        <DropdownMenuItem @click="openActionDialog(player, 'ban')" v-if="authStore.getServerPermissions(serverId as string).includes('ban')">
+                        <DropdownMenuItem @click="openActionDialog(player, 'ban')" v-if="authStore.getServerPermission(serverId as string, 'ban')">
                           <Icon name="lucide:ban" class="mr-2 h-4 w-4 text-red-500" />
                           <span>Ban Player</span>
                         </DropdownMenuItem>

--- a/web/pages/servers/[serverId]/disconnected-players.vue
+++ b/web/pages/servers/[serverId]/disconnected-players.vue
@@ -385,7 +385,7 @@ async function executePlayerAction() {
                       </Button>
                     </DropdownMenuTrigger>
                     <DropdownMenuContent align="end">
-                      <DropdownMenuItem @click="openActionDialog(player, 'ban')" v-if="authStore.getServerPermissions(serverId as string).includes('ban')">
+                      <DropdownMenuItem @click="openActionDialog(player, 'ban')" v-if="authStore.getServerPermission(serverId as string, 'ban')">
                         <Icon name="lucide:ban" class="mr-2 h-4 w-4 text-red-500" />
                         <span>Ban Player</span>
                       </DropdownMenuItem>

--- a/web/stores/auth.ts
+++ b/web/stores/auth.ts
@@ -54,6 +54,12 @@ export const useAuthStore = defineStore("auth", {
     },
     getServerPermission(serverId: string, permission: string) {
       const permissions = this.serverPermissions[serverId];
+
+      // If first permission is * then return true
+      if (permissions[0] === "*") {
+        return true;
+      }
+
       return Array.isArray(permissions) && (permissions.includes(permission) || permissions.length > 0);
     },
     setUser(user: User) {


### PR DESCRIPTION
This pull request introduces the implementation of an RCON Manager to better manage RCON connections within the project. The main goal of this update is to enhance the efficiency and maintainability of the RCON connection handling process.

- [x] Fix issue of after one command is sent the next can not be
- [x] Ensure total connections remain at 2 for a single server
- [x] When a server is added or deleted remove it from the manager
- [x] API Endpoints
	- [x] Manually subscribe to events such as `CHAT_MESSAGE` or `SQUAD_CREATE`