### PR TITLE
feat(workflow-stats): Add server-side computation of workflow execution stats

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -345,6 +345,7 @@ func NewRouter(serverDependencies *Dependencies) *gin.Engine {
 						workflowGroup.PUT("", server.ServerWorkflowUpdate)
 						workflowGroup.DELETE("", server.ServerWorkflowDelete)
 						workflowGroup.GET("/executions", server.ServerWorkflowExecutions)
+						workflowGroup.GET("/executions/stats", server.ServerWorkflowExecutionStats)
 
 						// Workflow execution details and logs
 						executionGroup := workflowGroup.Group("/executions/:executionId")


### PR DESCRIPTION
Implement server-side workflow execution statistics to improve
performance and reduce client-side calculations. Changes include:

- Add new API endpoint for fetching workflow execution stats
- Create database method to compute aggregate statistics
- Enhance frontend component to use server-side stats
- Fallback to client-side calculations if server stats unavailable
- Compute total executions, success rate, average duration, and
  running execution count