### PR TITLE
fix(server): MOTD auto-upload feedback on rule changes

### DIFF
--- a/internal/server/servers_motd.go
+++ b/internal/server/servers_motd.go
@@ -581,14 +581,17 @@ func (s *Server) triggerMOTDUpload(ctx context.Context, serverID uuid.UUID) {
 	s.updateMOTDUploadSuccess(ctx, config.ID, content)
 }
 
-// TriggerMOTDUploadIfEnabled is exported for use by rules bulk update
-func (s *Server) TriggerMOTDUploadIfEnabled(ctx context.Context, serverID uuid.UUID) {
+// TriggerMOTDUploadIfEnabled is exported for use by rules bulk update.
+// Returns true if upload was triggered, false otherwise.
+func (s *Server) TriggerMOTDUploadIfEnabled(ctx context.Context, serverID uuid.UUID) bool {
 	config, err := s.fetchOrCreateMOTDConfig(ctx, serverID)
 	if err != nil {
-		return
+		return false
 	}
 
 	if config.AutoUploadOnChange && config.UploadEnabled {
 		go s.triggerMOTDUpload(context.Background(), serverID)
+		return true
 	}
+	return false
 }

--- a/internal/server/servers_rules.go
+++ b/internal/server/servers_rules.go
@@ -521,7 +521,10 @@ func (s *Server) bulkUpdateServerRules(c *gin.Context) {
 	}
 
 	// Trigger MOTD auto-upload if enabled
-	s.TriggerMOTDUploadIfEnabled(c.Request.Context(), serverID)
+	motdAutoUploaded := s.TriggerMOTDUploadIfEnabled(c.Request.Context(), serverID)
 
-	c.JSON(http.StatusOK, updatedRules)
+	c.JSON(http.StatusOK, gin.H{
+		"rules":              updatedRules,
+		"motd_auto_uploaded": motdAutoUploaded,
+	})
 }

--- a/web/pages/servers/[serverId]/rules.vue
+++ b/web/pages/servers/[serverId]/rules.vue
@@ -598,12 +598,21 @@ async function saveAllRules() {
     hasUnsavedChanges.value = false;
     await fetchRules();
 
-    // Show success toast
-    toast({
-      title: "Rules Saved",
-      description: "All rule changes have been saved successfully",
-      variant: "default",
-    });
+    // Show success toast with MOTD upload status
+    const motdAutoUploaded = (data.value as any)?.motd_auto_uploaded;
+    if (motdAutoUploaded) {
+      toast({
+        title: "Rules Saved & MOTD Uploaded",
+        description: "Rules saved and MOTD automatically uploaded to game server",
+        variant: "default",
+      });
+    } else {
+      toast({
+        title: "Rules Saved",
+        description: "All rule changes have been saved successfully",
+        variant: "default",
+      });
+    }
 
   } catch (err: any) {
     error.value = err.message || "Error saving rules";


### PR DESCRIPTION
Modify TriggerMOTDUploadIfEnabled to return boolean indicating
upload status. Update rule update endpoint to return MOTD upload
status, and frontend to display appropriate toast message based
on auto-upload result.