### PR TITLE
refactor(uuid): Add fallback UUID generation utility

### DIFF
--- a/web/components/WorkflowEditor.vue
+++ b/web/components/WorkflowEditor.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { ref, computed, watch } from "vue";
+import { generateUUID } from "~/utils/uuid";
 import {
     Plus,
     Trash2,
@@ -252,7 +253,7 @@ function shouldShowField(field: any, stepConfig: Record<string, any>): boolean {
 
 // Helper functions
 function generateId(): string {
-    return crypto.randomUUID();
+    return generateUUID();
 }
 
 function getStepIcon(type: string) {

--- a/web/pages/servers/[serverId]/rules.vue
+++ b/web/pages/servers/[serverId]/rules.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { ref, onMounted, onUnmounted, computed } from 'vue'
+import { generateUUID } from '~/utils/uuid'
 import { onBeforeRouteLeave } from 'vue-router'
 import { FileText, Layers, Download, Code, Upload, Save, ChevronDown, ChevronUp, Minimize2, Maximize2, Plus } from 'lucide-vue-next'
 import RuleComponent from '~/components/RuleComponent.vue'
@@ -130,7 +131,7 @@ async function fetchRules() {
 
 const addNewRule = (type: 'rule') => {
   const newRule: ServerRule = {
-    id: crypto.randomUUID(),
+    id: generateUUID(),
     server_id: serverId,
     parent_id: null,
     display_order: rules.value.length,
@@ -185,7 +186,7 @@ const handleFileImport = (event: Event) => {
         if (Array.isArray(importedRules)) {
           rules.value = importedRules.map((rule, index) => ({
             ...rule,
-            id: rule.id || crypto.randomUUID(),
+            id: rule.id || generateUUID(),
             display_order: index,
             server_id: serverId,
             created_at: rule.created_at || new Date().toISOString(),
@@ -231,7 +232,7 @@ const parseTextImport = (content: string): ServerRule[] => {
         importedRules.push(currentRule);
       }
       currentRule = {
-        id: crypto.randomUUID(),
+        id: generateUUID(),
         server_id: serverId,
         display_order: importedRules.length,
         title: mainRuleMatch[2],
@@ -248,7 +249,7 @@ const parseTextImport = (content: string): ServerRule[] => {
     const subRuleMatch = trimmed.match(/^(\d+\.\d+)\.\s*(.+)$/);
     if (subRuleMatch && currentRule) {
       const subRule: ServerRule = {
-        id: crypto.randomUUID(),
+        id: generateUUID(),
         server_id: currentRule.server_id,
         parent_id: currentRule.id,
         display_order: currentRule.sub_rules?.length || 0,
@@ -368,7 +369,7 @@ const addSubRule = (parentId: string) => {
     return rulesList.map(rule => {
       if (rule.id === parentId) {
         const newSubRule: ServerRule = {
-          id: crypto.randomUUID(),
+          id: generateUUID(),
           server_id: rule.server_id,
           parent_id: rule.id,
           display_order: rule.sub_rules?.length || 0,
@@ -407,7 +408,7 @@ const addAction = (ruleId: string) => {
     return rulesList.map(rule => {
       if (rule.id === ruleId) {
         const newAction: ServerRuleAction = {
-          id: crypto.randomUUID(),
+          id: generateUUID(),
           rule_id: rule.id,
           violation_count: 1,
           action_type: 'WARN',

--- a/web/utils/uuid.ts
+++ b/web/utils/uuid.ts
@@ -1,0 +1,24 @@
+/**
+ * Generate a UUID v4 string.
+ *
+ * Uses crypto.randomUUID() when available (secure contexts) and
+ * falls back to a manual implementation using crypto.getRandomValues()
+ * for non-secure contexts (e.g. plain HTTP).
+ */
+export function generateUUID(): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+
+  // Fallback: build a UUID v4 from random bytes
+  const bytes = new Uint8Array(16);
+  crypto.getRandomValues(bytes);
+
+  // Set version (4) and variant (RFC 4122) bits
+  bytes[6] = (bytes[6] & 0x0f) | 0x40;
+  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+
+  const hex = Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('');
+
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}


### PR DESCRIPTION
Replace crypto.randomUUID() with a custom generateUUID() function
that supports environments without secure context. Implement a
robust random UUID generation method using crypto.getRandomValues()
for broader browser compatibility.