### PR TITLE
fix: lock down all routes with PBAC permissions and fix Permission components

### DIFF
--- a/web/pages/servers/[serverId]/audit-logs.vue
+++ b/web/pages/servers/[serverId]/audit-logs.vue
@@ -29,6 +29,8 @@ import {
 } from "~/components/ui/dialog";
 import { Separator } from "~/components/ui/separator";
 
+definePageMeta({ middleware: ["auth"] });
+
 const route = useRoute();
 const serverId = route.params.serverId;
 

--- a/web/pages/servers/[serverId]/banned-players.vue
+++ b/web/pages/servers/[serverId]/banned-players.vue
@@ -65,6 +65,8 @@ import { toast } from "~/components/ui/toast";
 import { canPreview, getMediaCategory } from "~/utils/mediaTypes";
 import { UI_PERMISSIONS } from "~/constants/permissions";
 
+definePageMeta({ middleware: ["auth"] });
+
 const authStore = useAuthStore();
 const runtimeConfig = useRuntimeConfig();
 const route = useRoute();

--- a/web/pages/servers/[serverId]/console.vue
+++ b/web/pages/servers/[serverId]/console.vue
@@ -9,6 +9,8 @@ import {
   DialogTitle,
 } from "~/components/ui/dialog";
 
+definePageMeta({ middleware: ["auth"] });
+
 const route = useRoute();
 const serverId = route.params.serverId;
 

--- a/web/pages/servers/[serverId]/disconnected-players.vue
+++ b/web/pages/servers/[serverId]/disconnected-players.vue
@@ -8,6 +8,8 @@ import { useToast } from "~/components/ui/toast";
 import type { Player } from "~/types";
 import PlayerActionMenu from "~/components/PlayerActionMenu.vue";
 
+definePageMeta({ middleware: ["auth"] });
+
 const authStore = useAuthStore();
 const route = useRoute();
 const serverId = route.params.serverId;

--- a/web/pages/servers/[serverId]/index.vue
+++ b/web/pages/servers/[serverId]/index.vue
@@ -39,6 +39,8 @@ import {
 } from "~/components/ui/select";
 import { toast } from "~/components/ui/toast";
 
+definePageMeta({ middleware: ["auth"] });
+
 const route = useRoute();
 const serverId = route.params.serverId;
 const authStore = useAuthStore();

--- a/web/pages/servers/[serverId]/motd.vue
+++ b/web/pages/servers/[serverId]/motd.vue
@@ -317,6 +317,8 @@ import { Card, CardContent, CardHeader, CardTitle } from "~/components/ui/card";
 import { Switch } from "~/components/ui/switch";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "~/components/ui/select";
 
+definePageMeta({ middleware: ["auth"] });
+
 interface MOTDConfig {
     id: string;
     server_id: string;

--- a/web/pages/servers/[serverId]/rules.vue
+++ b/web/pages/servers/[serverId]/rules.vue
@@ -10,6 +10,8 @@ import { useToast } from "~/components/ui/toast"
 import { useAuthStore } from "~/stores/auth"
 import { UI_PERMISSIONS } from "~/constants/permissions"
 
+definePageMeta({ middleware: ["auth"] });
+
 interface ServerRuleAction {
   id: string;
   rule_id: string;

--- a/web/pages/servers/[serverId]/settings.vue
+++ b/web/pages/servers/[serverId]/settings.vue
@@ -467,6 +467,8 @@ import {
     DialogTitle,
 } from "~/components/ui/dialog";
 
+definePageMeta({ middleware: ["auth"] });
+
 const route = useRoute();
 const router = useRouter();
 const { toast } = useToast();

--- a/web/pages/servers/[serverId]/teams-and-squads.vue
+++ b/web/pages/servers/[serverId]/teams-and-squads.vue
@@ -13,6 +13,8 @@ import { Progress } from "~/components/ui/progress";
 import { Switch } from "~/components/ui/switch";
 import { Label } from "~/components/ui/label";
 
+definePageMeta({ middleware: ["auth"] });
+
 const route = useRoute();
 const serverId = route.params.serverId;
 const { toast } = useToast();

--- a/web/pages/servers/[serverId]/workflows/[workflowId]/executions/[executionId].vue
+++ b/web/pages/servers/[serverId]/workflows/[workflowId]/executions/[executionId].vue
@@ -1193,6 +1193,7 @@ onMounted(() => {
 
 // Page metadata
 definePageMeta({
+    middleware: ["auth"],
     layout: "default",
 });
 


### PR DESCRIPTION
- Fix Vue 3 boolean casting bug in PermissionButton, PermissionDropdownMenuItem,
  and PermissionContextMenuItem (boolean | null with withDefaults)
- Convert SquadActionMenu from old bare permission strings to PBAC constants
- Add RequirePermission/RequireAnyPermission middleware to all unprotected
  backend routes (RCON execute, feeds, bans, rules, events, evidence, etc.)
- Restrict roles/admins routes to super admin only
- Make plugins, MOTD, and workflows accessible to users with rcon:manageserver
- Remove AuthIsSuperAdmin from global /api/plugins/available route
- Add auth middleware to all frontend server pages
- Add super admin guard to Users & Roles page
- Fix SQL scan mismatch in GetServerById (missing BanEnforcementMode)
- Remove deprecated getServerPermission from auth store