### PR TITLE
fix: enforce permission scope separation (ui: vs rcon:) and drop unused api: category

### DIFF
--- a/internal/db/migrations/000022_cleanup_permissions.down.sql
+++ b/internal/db/migrations/000022_cleanup_permissions.down.sql
@@ -1,0 +1,57 @@
+-- Reverse migration 000022: Restore api: permissions, remove MOTD permissions
+
+-- =============================================================================
+-- PHASE 1: Restore api: permission definitions
+-- =============================================================================
+
+INSERT INTO permissions (code, category, name, description, squad_permission) VALUES
+    ('api:servers:read', 'api', 'Read Servers', 'API access to read server data', NULL),
+    ('api:servers:write', 'api', 'Write Servers', 'API access to modify server settings', NULL),
+    ('api:bans:read', 'api', 'Read Bans', 'API access to read bans', NULL),
+    ('api:bans:write', 'api', 'Write Bans', 'API access to create/modify bans', NULL),
+    ('api:players:read', 'api', 'Read Players', 'API access to read player data', NULL),
+    ('api:rcon:execute', 'api', 'Execute RCON', 'API access to execute RCON commands', NULL),
+    ('api:plugins:manage', 'api', 'Manage Plugins', 'API access to manage plugins', NULL),
+    ('api:workflows:manage', 'api', 'Manage Workflows', 'API access to manage workflows', NULL),
+    ('api:rules:manage', 'api', 'Manage Rules', 'API access to manage server rules', NULL),
+    ('api:evidence:upload', 'api', 'Upload Evidence', 'API access to upload evidence files', NULL),
+    ('api:evidence:read', 'api', 'Read Evidence', 'API access to read evidence files', NULL)
+ON CONFLICT (code) DO NOTHING;
+
+-- Restore api: permissions to Server Admin template
+INSERT INTO role_template_permissions (role_template_id, permission_id)
+SELECT '00000000-0000-0000-0000-000000000002', id FROM permissions
+WHERE code IN (
+    'api:servers:read', 'api:servers:write', 'api:bans:read', 'api:bans:write',
+    'api:players:read', 'api:rcon:execute', 'api:plugins:manage', 'api:workflows:manage',
+    'api:rules:manage', 'api:evidence:upload', 'api:evidence:read'
+)
+ON CONFLICT DO NOTHING;
+
+-- Restore api: permissions to Moderator template
+INSERT INTO role_template_permissions (role_template_id, permission_id)
+SELECT '00000000-0000-0000-0000-000000000003', id FROM permissions
+WHERE code IN ('api:servers:read', 'api:bans:read', 'api:bans:write', 'api:players:read',
+               'api:evidence:upload', 'api:evidence:read')
+ON CONFLICT DO NOTHING;
+
+-- Restore api: permissions to Junior Moderator template
+INSERT INTO role_template_permissions (role_template_id, permission_id)
+SELECT '00000000-0000-0000-0000-000000000004', id FROM permissions
+WHERE code IN ('api:servers:read', 'api:players:read')
+ON CONFLICT DO NOTHING;
+
+-- =============================================================================
+-- PHASE 2: Remove MOTD permissions
+-- =============================================================================
+
+-- Remove MOTD permissions from server role assignments
+DELETE FROM server_role_permissions
+WHERE permission_id IN (SELECT id FROM permissions WHERE code IN ('ui:motd:view', 'ui:motd:manage'));
+
+-- Remove MOTD permissions from role template assignments
+DELETE FROM role_template_permissions
+WHERE permission_id IN (SELECT id FROM permissions WHERE code IN ('ui:motd:view', 'ui:motd:manage'));
+
+-- Remove MOTD permission definitions
+DELETE FROM permissions WHERE code IN ('ui:motd:view', 'ui:motd:manage');

--- a/internal/db/migrations/000022_cleanup_permissions.up.sql
+++ b/internal/db/migrations/000022_cleanup_permissions.up.sql
@@ -1,0 +1,48 @@
+-- Migration 000022: Cleanup permission scopes
+-- 1. Seed missing MOTD permissions (ui:motd:view, ui:motd:manage)
+-- 2. Remove unused api: category permissions
+
+-- =============================================================================
+-- PHASE 1: Seed missing MOTD permissions
+-- =============================================================================
+
+INSERT INTO permissions (code, category, name, description, squad_permission) VALUES
+    ('ui:motd:view', 'ui', 'View MOTD', 'Access to view MOTD configuration', NULL),
+    ('ui:motd:manage', 'ui', 'Manage MOTD', 'Permission to manage MOTD settings and uploads', NULL)
+ON CONFLICT (code) DO NOTHING;
+
+-- Add MOTD permissions to Server Admin template
+INSERT INTO role_template_permissions (role_template_id, permission_id)
+SELECT '00000000-0000-0000-0000-000000000002', id FROM permissions
+WHERE code IN ('ui:motd:view', 'ui:motd:manage')
+ON CONFLICT DO NOTHING;
+
+-- Add MOTD view to Moderator template
+INSERT INTO role_template_permissions (role_template_id, permission_id)
+SELECT '00000000-0000-0000-0000-000000000003', id FROM permissions
+WHERE code = 'ui:motd:view'
+ON CONFLICT DO NOTHING;
+
+-- Backfill: grant MOTD permissions to existing server roles that have rcon:manageserver
+INSERT INTO server_role_permissions (server_role_id, permission_id)
+SELECT DISTINCT srp.server_role_id, p2.id
+FROM server_role_permissions srp
+JOIN permissions p1 ON srp.permission_id = p1.id AND p1.code = 'rcon:manageserver'
+CROSS JOIN permissions p2
+WHERE p2.code IN ('ui:motd:view', 'ui:motd:manage')
+ON CONFLICT DO NOTHING;
+
+-- =============================================================================
+-- PHASE 2: Remove unused api: category permissions
+-- =============================================================================
+
+-- Remove api: permissions from server role assignments
+DELETE FROM server_role_permissions
+WHERE permission_id IN (SELECT id FROM permissions WHERE category = 'api');
+
+-- Remove api: permissions from role template assignments
+DELETE FROM role_template_permissions
+WHERE permission_id IN (SELECT id FROM permissions WHERE category = 'api');
+
+-- Remove api: permission definitions
+DELETE FROM permissions WHERE category = 'api';

--- a/internal/permissions/permissions.go
+++ b/internal/permissions/permissions.go
@@ -12,7 +12,6 @@ type Category string
 const (
 	CategorySystem Category = "system"
 	CategoryUI     Category = "ui"
-	CategoryAPI    Category = "api"
 	CategoryRCON   Category = "rcon"
 )
 
@@ -49,21 +48,6 @@ const (
 	UIBanListsManage  Permission = "ui:ban_lists:manage"
 	UIMOTDView        Permission = "ui:motd:view"
 	UIMOTDManage      Permission = "ui:motd:manage"
-)
-
-// API Permissions - Control access to API endpoints.
-const (
-	APIServersRead     Permission = "api:servers:read"
-	APIServersWrite    Permission = "api:servers:write"
-	APIBansRead        Permission = "api:bans:read"
-	APIBansWrite       Permission = "api:bans:write"
-	APIPlayersRead     Permission = "api:players:read"
-	APIRconExecute     Permission = "api:rcon:execute"
-	APIPluginsManage   Permission = "api:plugins:manage"
-	APIWorkflowsManage Permission = "api:workflows:manage"
-	APIRulesManage     Permission = "api:rules:manage"
-	APIEvidenceUpload  Permission = "api:evidence:upload"
-	APIEvidenceRead    Permission = "api:evidence:read"
 )
 
 // RCON/Squad Permissions - Map to Squad's admin.cfg permissions.
@@ -158,8 +142,6 @@ func (p Permission) GetCategory() Category {
 	switch parts[0] {
 	case "ui":
 		return CategoryUI
-	case "api":
-		return CategoryAPI
 	case "rcon":
 		return CategoryRCON
 	default:
@@ -186,11 +168,6 @@ func (p Permission) IsUI() bool {
 	return p.GetCategory() == CategoryUI
 }
 
-// IsAPI returns true if this is an API permission.
-func (p Permission) IsAPI() bool {
-	return p.GetCategory() == CategoryAPI
-}
-
 // IsWildcard returns true if this is the wildcard permission.
 func (p Permission) IsWildcard() bool {
 	return p == Wildcard
@@ -213,10 +190,6 @@ func AllPermissions() []Permission {
 		UIPlayersView, UIPlayersKick, UIPlayersWarn, UIPlayersMove,
 		UIRulesView, UIRulesManage, UIBanListsView, UIBanListsManage,
 		UIMOTDView, UIMOTDManage,
-		// API
-		APIServersRead, APIServersWrite, APIBansRead, APIBansWrite,
-		APIPlayersRead, APIRconExecute, APIPluginsManage, APIWorkflowsManage,
-		APIRulesManage, APIEvidenceUpload, APIEvidenceRead,
 		// RCON
 		RCONReserve, RCONBalance, RCONCanSeeAdminChat, RCONManageServer,
 		RCONTeamChange, RCONChat, RCONCameraman, RCONKick, RCONBan,
@@ -236,15 +209,6 @@ func UIPermissions() []Permission {
 		UIPlayersView, UIPlayersKick, UIPlayersWarn, UIPlayersMove,
 		UIRulesView, UIRulesManage, UIBanListsView, UIBanListsManage,
 		UIMOTDView, UIMOTDManage,
-	}
-}
-
-// APIPermissions returns all API permissions.
-func APIPermissions() []Permission {
-	return []Permission{
-		APIServersRead, APIServersWrite, APIBansRead, APIBansWrite,
-		APIPlayersRead, APIRconExecute, APIPluginsManage, APIWorkflowsManage,
-		APIRulesManage, APIEvidenceUpload, APIEvidenceRead,
 	}
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -215,24 +215,24 @@ func NewRouter(serverDependencies *Dependencies) *gin.Engine {
 			serverGroup := serversGroup.Group("/:serverId")
 			{
 				serverGroup.GET("", server.ServerGet)
-				serverGroup.PUT("", server.RequireAnyPermission(permissions.UISettingsManage, permissions.RCONManageServer), server.ServerUpdate)
+				serverGroup.PUT("", server.RequirePermission(permissions.UISettingsManage), server.ServerUpdate)
 				serverGroup.DELETE("", server.AuthIsSuperAdmin(), server.ServerDelete)
 
 				serverGroup.GET("/metrics", server.ServerMetrics)
 				serverGroup.GET("/metrics/history", server.ServerMetricsHistory)
 				serverGroup.GET("/status", server.ServerStatus)
-				serverGroup.GET("/audit-logs", server.RequirePermission(permissions.RCONManageServer), server.ServerAuditLogs)
+				serverGroup.GET("/audit-logs", server.RequirePermission(permissions.UIAuditLogsView), server.ServerAuditLogs)
 
 				serverGroup.GET("/rcon/commands", server.RconCommandList)
 				serverGroup.GET("/rcon/commands/autocomplete", server.RconCommandAutocomplete)
-				serverGroup.POST("/rcon/execute", server.RequireAnyPermission(permissions.UIConsoleExecute, permissions.RCONManageServer), server.ServerRconExecute)
+				serverGroup.POST("/rcon/execute", server.RequirePermission(permissions.UIConsoleExecute), server.ServerRconExecute)
 				serverGroup.GET("/rcon/server-population", server.ServerRconServerPopulation)
 				serverGroup.GET("/rcon/available-layers", server.ServerRconAvailableLayers)
-				serverGroup.GET("/rcon/events", server.RequirePermission(permissions.RCONManageServer), server.ServerRconEvents)
-				serverGroup.POST("/rcon/force-restart", server.RequirePermission(permissions.RCONManageServer), server.ServerRconForceRestart)
+				serverGroup.GET("/rcon/events", server.RequirePermission(permissions.UIConsoleView), server.ServerRconEvents)
+				serverGroup.POST("/rcon/force-restart", server.RequirePermission(permissions.UISettingsManage), server.ServerRconForceRestart)
 
 				// Log watcher management
-				serverGroup.POST("/logwatcher/restart", server.RequirePermission(permissions.RCONManageServer), server.ServerLogwatcherRestart)
+				serverGroup.POST("/logwatcher/restart", server.RequirePermission(permissions.UISettingsManage), server.ServerLogwatcherRestart)
 
 				// Live feeds for chat, connections, and teamkills
 				serverGroup.GET("/feeds", server.RequirePermission(permissions.UIFeedsView), server.ServerFeeds)
@@ -265,9 +265,9 @@ func NewRouter(serverDependencies *Dependencies) *gin.Engine {
 				serverGroup.DELETE("/bans/:banId", server.RequirePermission(permissions.UIBansDelete), server.ServerBansRemove)
 
 				// Ban list subscription management
-				serverGroup.GET("/ban-list-subscriptions", server.RequirePermission(permissions.RCONManageServer), server.ServerBanListSubscriptions)
-				serverGroup.POST("/ban-list-subscriptions", server.RequirePermission(permissions.RCONManageServer), server.ServerBanListSubscriptionCreate)
-				serverGroup.DELETE("/ban-list-subscriptions/:banListId", server.RequirePermission(permissions.RCONManageServer), server.ServerBanListSubscriptionDelete)
+				serverGroup.GET("/ban-list-subscriptions", server.RequirePermission(permissions.UIBanListsView), server.ServerBanListSubscriptions)
+				serverGroup.POST("/ban-list-subscriptions", server.RequirePermission(permissions.UIBanListsManage), server.ServerBanListSubscriptionCreate)
+				serverGroup.DELETE("/ban-list-subscriptions/:banListId", server.RequirePermission(permissions.UIBanListsManage), server.ServerBanListSubscriptionDelete)
 
 				// Player action endpoints
 				serverGroup.POST("/rcon/kick-player", server.RequirePermission(permissions.UIPlayersKick), server.ServerRconKickPlayer)
@@ -289,8 +289,8 @@ func NewRouter(serverDependencies *Dependencies) *gin.Engine {
 				// Plugin management routes for specific servers
 				pluginGroup := serverGroup.Group("/plugins")
 				{
-					pluginManagePerm := server.RequireAnyPermission(permissions.UIPluginsManage, permissions.RCONManageServer)
-					pluginViewPerm := server.RequireAnyPermission(permissions.UIPluginsView, permissions.RCONManageServer)
+					pluginManagePerm := server.RequirePermission(permissions.UIPluginsManage)
+					pluginViewPerm := server.RequirePermission(permissions.UIPluginsView)
 
 					pluginGroup.GET("", pluginViewPerm, server.ServerPluginList)
 					pluginGroup.GET("/logs", pluginManagePerm, server.ServerPluginLogsAll)
@@ -328,11 +328,11 @@ func NewRouter(serverDependencies *Dependencies) *gin.Engine {
 				// Server MOTD
 				motdGroup := serverGroup.Group("/motd")
 				{
-					motdManagePerm := server.RequireAnyPermission(permissions.UIMOTDManage, permissions.RCONManageServer)
+					motdManagePerm := server.RequirePermission(permissions.UIMOTDManage)
 
-					motdGroup.GET("", server.RequireAnyPermission(permissions.UIMOTDView, permissions.RCONManageServer), server.getMOTDConfig)
+					motdGroup.GET("", server.RequirePermission(permissions.UIMOTDView), server.getMOTDConfig)
 					motdGroup.PUT("", motdManagePerm, server.updateMOTDConfig)
-					motdGroup.GET("/preview", server.RequireAnyPermission(permissions.UIMOTDView, permissions.RCONManageServer), server.previewMOTD)
+					motdGroup.GET("/preview", server.RequirePermission(permissions.UIMOTDView), server.previewMOTD)
 					motdGroup.POST("/upload", motdManagePerm, server.uploadMOTD)
 					motdGroup.POST("/test-connection", motdManagePerm, server.testMOTDConnection)
 				}
@@ -340,7 +340,7 @@ func NewRouter(serverDependencies *Dependencies) *gin.Engine {
 				// Server Workflows
 				workflowsGroup := serverGroup.Group("/workflows")
 				{
-					workflowsGroup.Use(server.RequireAnyPermission(permissions.UIWorkflowsManage, permissions.RCONManageServer))
+					workflowsGroup.Use(server.RequirePermission(permissions.UIWorkflowsManage))
 					workflowsGroup.GET("", server.ServerWorkflowsList)
 					workflowsGroup.POST("", server.ServerWorkflowCreate)
 

--- a/web/composables/usePermissions.ts
+++ b/web/composables/usePermissions.ts
@@ -1,10 +1,6 @@
 import { computed, type ComputedRef } from "vue";
 import { useAuthStore } from "@/stores/auth";
-import {
-  type Permission,
-  UI_PERMISSIONS,
-  RCON_PERMISSIONS,
-} from "@/constants/permissions";
+import { type Permission, UI_PERMISSIONS } from "@/constants/permissions";
 
 /**
  * Composable for checking permissions in Vue components.
@@ -158,14 +154,6 @@ export function usePermissions(serverId?: string | ComputedRef<string>) {
     hasPermission(UI_PERMISSIONS.BAN_LISTS_MANAGE)
   );
 
-  // RCON Server permissions
-  const canManageServer = computed(() =>
-    hasPermission(RCON_PERMISSIONS.MANAGE_SERVER)
-  );
-  const canChangeMap = computed(() =>
-    hasPermission(RCON_PERMISSIONS.CHANGE_MAP)
-  );
-
   return {
     // Core checks
     isSuperAdmin,
@@ -220,9 +208,5 @@ export function usePermissions(serverId?: string | ComputedRef<string>) {
     // Ban Lists
     canViewBanLists,
     canManageBanLists,
-
-    // RCON Server
-    canManageServer,
-    canChangeMap,
   };
 }

--- a/web/constants/permissions.ts
+++ b/web/constants/permissions.ts
@@ -1,7 +1,7 @@
 // Permission constants for the PBAC system
 // These must stay in sync with internal/permissions/permissions.go
 
-export type PermissionCategory = "system" | "ui" | "api" | "rcon";
+export type PermissionCategory = "system" | "ui" | "rcon";
 
 // Wildcard permission grants all access
 export const PERMISSION_WILDCARD = "*";
@@ -38,21 +38,6 @@ export const UI_PERMISSIONS = {
   MOTD_MANAGE: "ui:motd:manage",
 } as const;
 
-// API Permissions - Control access to API endpoints
-export const API_PERMISSIONS = {
-  SERVERS_READ: "api:servers:read",
-  SERVERS_WRITE: "api:servers:write",
-  BANS_READ: "api:bans:read",
-  BANS_WRITE: "api:bans:write",
-  PLAYERS_READ: "api:players:read",
-  RCON_EXECUTE: "api:rcon:execute",
-  PLUGINS_MANAGE: "api:plugins:manage",
-  WORKFLOWS_MANAGE: "api:workflows:manage",
-  RULES_MANAGE: "api:rules:manage",
-  EVIDENCE_UPLOAD: "api:evidence:upload",
-  EVIDENCE_READ: "api:evidence:read",
-} as const;
-
 // RCON/Squad Permissions - Map to Squad's admin.cfg permissions
 export const RCON_PERMISSIONS = {
   RESERVE: "rcon:reserve",
@@ -83,7 +68,6 @@ export const RCON_PERMISSIONS = {
 export const Permissions = {
   WILDCARD: PERMISSION_WILDCARD,
   UI: UI_PERMISSIONS,
-  API: API_PERMISSIONS,
   RCON: RCON_PERMISSIONS,
 } as const;
 
@@ -91,7 +75,6 @@ export const Permissions = {
 export type Permission =
   | typeof PERMISSION_WILDCARD
   | (typeof UI_PERMISSIONS)[keyof typeof UI_PERMISSIONS]
-  | (typeof API_PERMISSIONS)[keyof typeof API_PERMISSIONS]
   | (typeof RCON_PERMISSIONS)[keyof typeof RCON_PERMISSIONS];
 
 // Maps RCON permission codes to Squad's admin.cfg format
@@ -127,8 +110,6 @@ export function getPermissionCategory(permission: string): PermissionCategory {
   switch (prefix) {
     case "ui":
       return "ui";
-    case "api":
-      return "api";
     case "rcon":
       return "rcon";
     default:
@@ -146,11 +127,6 @@ export function isUiPermission(permission: string): boolean {
   return permission.startsWith("ui:");
 }
 
-// Helper to check if permission is API type
-export function isApiPermission(permission: string): boolean {
-  return permission.startsWith("api:");
-}
-
 // Helper to convert RCON permission to Squad format
 export function toSquadPermission(permission: string): string | null {
   return SQUAD_PERMISSION_MAP[permission] || null;
@@ -160,7 +136,6 @@ export function toSquadPermission(permission: string): string | null {
 export const PERMISSION_CATEGORY_NAMES: Record<PermissionCategory, string> = {
   system: "System",
   ui: "User Interface",
-  api: "API Access",
   rcon: "RCON / Squad Server",
 };
 
@@ -168,6 +143,5 @@ export const PERMISSION_CATEGORY_NAMES: Record<PermissionCategory, string> = {
 export const ALL_PERMISSIONS: Permission[] = [
   PERMISSION_WILDCARD,
   ...Object.values(UI_PERMISSIONS),
-  ...Object.values(API_PERMISSIONS),
   ...Object.values(RCON_PERMISSIONS),
 ];

--- a/web/lib/permissions.ts
+++ b/web/lib/permissions.ts
@@ -27,7 +27,6 @@ export function formatPermissionName(permission: Permission | string): string {
   if (actionParts.length === 1 && actionParts[0] === "*") {
     const categoryNames: Record<string, string> = {
       ui: "All UI Permissions",
-      api: "All API Permissions",
       rcon: "All RCON Permissions",
       system: "All System Permissions",
     };

--- a/web/navigation/server.ts
+++ b/web/navigation/server.ts
@@ -1,4 +1,4 @@
-import { UI_PERMISSIONS, RCON_PERMISSIONS } from "@/constants/permissions";
+import { UI_PERMISSIONS } from "@/constants/permissions";
 
 export default [
   { heading: "Server" },
@@ -48,7 +48,7 @@ export default [
     to: {
       name: "servers-serverId-console",
     },
-    permissions: [UI_PERMISSIONS.CONSOLE_VIEW, RCON_PERMISSIONS.MANAGE_SERVER],
+    permissions: [UI_PERMISSIONS.CONSOLE_VIEW],
   },
   {
     title: "Feeds",
@@ -72,7 +72,7 @@ export default [
     to: {
       name: "servers-serverId-audit-logs",
     },
-    permissions: [UI_PERMISSIONS.AUDIT_LOGS_VIEW, RCON_PERMISSIONS.MANAGE_SERVER],
+    permissions: [UI_PERMISSIONS.AUDIT_LOGS_VIEW],
   },
   {
     title: "Rules",
@@ -88,7 +88,7 @@ export default [
     to: {
       name: "servers-serverId-motd",
     },
-    permissions: [UI_PERMISSIONS.MOTD_VIEW, RCON_PERMISSIONS.MANAGE_SERVER],
+    permissions: [UI_PERMISSIONS.MOTD_VIEW],
   },
   {
     title: "Plugins",
@@ -96,7 +96,7 @@ export default [
     to: {
       name: "servers-serverId-plugins",
     },
-    permissions: [UI_PERMISSIONS.PLUGINS_VIEW, RCON_PERMISSIONS.MANAGE_SERVER],
+    permissions: [UI_PERMISSIONS.PLUGINS_VIEW],
   },
   {
     title: "Workflows",
@@ -104,7 +104,7 @@ export default [
     to: {
       name: "servers-serverId-workflows",
     },
-    permissions: [UI_PERMISSIONS.WORKFLOWS_VIEW, RCON_PERMISSIONS.MANAGE_SERVER],
+    permissions: [UI_PERMISSIONS.WORKFLOWS_VIEW],
   },
   {
     title: "Settings",

--- a/web/pages/servers/[serverId]/users-and-roles.vue
+++ b/web/pages/servers/[serverId]/users-and-roles.vue
@@ -1086,8 +1086,6 @@ const getPermissionCategoryColor = (permCode: string): string => {
     switch (category) {
         case "ui":
             return "bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200";
-        case "api":
-            return "bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200";
         case "rcon":
             return "bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-200";
         default:


### PR DESCRIPTION
## Summary

- **Enforce scope separation**: `rcon:` permissions should only control what users can do on the Squad game server (maps to admin.cfg). All 15 routes that used `rcon:manageserver` as a UI access fallback now use proper `ui:` permissions instead.
- **Remove dead `api:` category**: 11 `api:` permissions were defined, seeded in DB, and assigned to role templates but never enforced anywhere. Removed from Go constants, TS constants, DB (via migration), and UI.
- **Seed missing MOTD permissions**: `ui:motd:view` and `ui:motd:manage` existed in code but were never seeded in the database. New migration adds them and backfills to existing roles that have `rcon:manageserver`.
