### PR TITLE
Set PGDATA env var for Postgres container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       - POSTGRES_USER=squad-aegis
       - POSTGRES_PASSWORD=squad-aegis
       - POSTGRES_DB=squad-aegis
-      - POSTGRES_INITDB_ARGS=
+      - PGDATA=/var/lib/postgresql/data
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U squad-aegis"]
       interval: 10s


### PR DESCRIPTION
Fix persistent volume usage by setting PGDATA instead of empty
POSTGRES_INITDB_ARGS. Docker Compose was creating new data directories
on each recreate because POSTGRES_INITDB_ARGS was empty; explicitly
setting PGDATA to /var/lib/postgresql/data ensures Postgres uses the
intended data directory and the named volume is honored.