### PR TITLE
Add default UUID for server_roles.id and update role insertion

### DIFF
--- a/internal/db/migrations/000023_add_server_roles_id_default.down.sql
+++ b/internal/db/migrations/000023_add_server_roles_id_default.down.sql
@@ -1,0 +1,4 @@
+-- Revert migration 000023: Remove DEFAULT from server_roles.id
+
+ALTER TABLE server_roles
+    ALTER COLUMN id DROP DEFAULT;

--- a/internal/db/migrations/000023_add_server_roles_id_default.up.sql
+++ b/internal/db/migrations/000023_add_server_roles_id_default.up.sql
@@ -1,0 +1,9 @@
+-- Migration 000023: Add DEFAULT gen_random_uuid() to server_roles.id
+-- The server_roles table was created in 000001 without a DEFAULT on the id column.
+-- Newer code paths (e.g., creating roles from templates) omit the id in INSERT
+-- statements, expecting the database to generate it.
+
+CREATE EXTENSION IF NOT EXISTS "pgcrypto";
+
+ALTER TABLE server_roles
+    ALTER COLUMN id SET DEFAULT gen_random_uuid();

--- a/internal/server/permissions.go
+++ b/internal/server/permissions.go
@@ -127,12 +127,11 @@ func (s *Server) ServerRoleCreateFromTemplate(c *gin.Context) {
 	defer tx.Rollback()
 
 	// Insert the new role
-	var roleId uuid.UUID
-	err = tx.QueryRowContext(c.Request.Context(), `
-		INSERT INTO server_roles (server_id, name, permissions, is_admin, created_at)
-		VALUES ($1, $2, '', $3, NOW())
-		RETURNING id
-	`, serverId, req.Name, template.IsAdmin).Scan(&roleId)
+	roleId := uuid.New()
+	_, err = tx.ExecContext(c.Request.Context(), `
+		INSERT INTO server_roles (id, server_id, name, permissions, is_admin, created_at)
+		VALUES ($1, $2, $3, '', $4, NOW())
+	`, roleId, serverId, req.Name, template.IsAdmin)
 	if err != nil {
 		responses.InternalServerError(c, err, nil)
 		return


### PR DESCRIPTION
Database inserts for server roles were failing with a NOT NULL
constraint on the id column because newer code paths (creating roles
from templates) omitted the id in INSERT statements. Add a migration
that sets server_roles.id default to gen_random_uuid() (with a down
migration to drop it) so the DB generates IDs automatically. Also update
the server role creation code to explicitly supply an id (uuid.New())
when inserting to ensure existing code paths remain compatible and avoid
transient errors.