### PR TITLE
fix(workflows): sandbox Lua execution state

### DIFF
--- a/internal/workflow_manager/workflow_manager.go
+++ b/internal/workflow_manager/workflow_manager.go
@@ -2950,7 +2950,7 @@ func (wm *WorkflowManager) executeLuaAction(context *models.WorkflowExecutionCon
 
 // executeLuaScript executes a LUA script with access to workflow context
 func (wm *WorkflowManager) executeLuaScript(workflowContext *models.WorkflowExecutionContext, step *models.WorkflowStep, script string) error {
-	L := lua.NewState()
+	L := wm.newSandboxedLuaState()
 	defer L.Close()
 
 	// Set timeout for script execution
@@ -2996,6 +2996,39 @@ func (wm *WorkflowManager) executeLuaScript(workflowContext *models.WorkflowExec
 
 	// Extract results from LUA state
 	return wm.extractLuaResults(L, workflowContext, step)
+}
+
+// newSandboxedLuaState creates a Lua state with only safe standard libraries.
+func (wm *WorkflowManager) newSandboxedLuaState() *lua.LState {
+	L := lua.NewState(lua.Options{SkipOpenLibs: true})
+
+	// Open only non-I/O and non-OS libraries.
+	L.Push(L.NewFunction(lua.OpenBase))
+	L.Push(lua.LString(lua.BaseLibName))
+	L.Call(1, 0)
+
+	L.Push(L.NewFunction(lua.OpenTable))
+	L.Push(lua.LString(lua.TabLibName))
+	L.Call(1, 0)
+
+	L.Push(L.NewFunction(lua.OpenString))
+	L.Push(lua.LString(lua.StringLibName))
+	L.Call(1, 0)
+
+	L.Push(L.NewFunction(lua.OpenMath))
+	L.Push(lua.LString(lua.MathLibName))
+	L.Call(1, 0)
+
+	L.Push(L.NewFunction(lua.OpenCoroutine))
+	L.Push(lua.LString(lua.CoroutineLibName))
+	L.Call(1, 0)
+
+	// Remove dangerous globals even if present through base library.
+	for _, name := range []string{"dofile", "loadfile", "io", "os", "package", "debug", "require", "module"} {
+		L.SetGlobal(name, lua.LNil)
+	}
+
+	return L
 }
 
 // setupLuaEnvironment sets up the LUA environment with workflow context and utilities

--- a/internal/workflow_manager/workflow_manager_test.go
+++ b/internal/workflow_manager/workflow_manager_test.go
@@ -1,6 +1,7 @@
 package workflow_manager
 
 import (
+	"strings"
 	"testing"
 
 	"go.codycody31.dev/squad-aegis/internal/models"
@@ -105,6 +106,64 @@ func TestGetFieldValue(t *testing.T) {
 				t.Errorf("getFieldValue(%q) = %v, expected %v", tt.field, result, tt.expected)
 			}
 		})
+	}
+}
+
+func TestNewSandboxedLuaStateDisablesDangerousLibraries(t *testing.T) {
+	wm := &WorkflowManager{}
+	L := wm.newSandboxedLuaState()
+	defer L.Close()
+
+	tests := []struct {
+		name        string
+		script      string
+		wantErrText string
+	}{
+		{
+			name:        "blocks os library access",
+			script:      `return os.execute("echo pwned")`,
+			wantErrText: "attempt to index a non-table object(nil) with key 'execute'",
+		},
+		{
+			name:        "blocks io library access",
+			script:      `return io.open("/etc/passwd", "r")`,
+			wantErrText: "attempt to index a non-table object(nil) with key 'open'",
+		},
+		{
+			name:        "blocks require",
+			script:      `return require("os")`,
+			wantErrText: "attempt to call a non-function object",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := L.DoString(tt.script)
+			if err == nil {
+				t.Fatalf("expected script to fail, but it succeeded")
+			}
+
+			if !strings.Contains(err.Error(), tt.wantErrText) {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestNewSandboxedLuaStateKeepsSafeLibraries(t *testing.T) {
+	wm := &WorkflowManager{}
+	L := wm.newSandboxedLuaState()
+	defer L.Close()
+
+	err := L.DoString(`
+		local value = string.upper("safe")
+		local rounded = math.floor(3.9)
+		if value ~= "SAFE" or rounded ~= 3 then
+			error("safe libs unavailable")
+		end
+	`)
+	if err != nil {
+		t.Fatalf("expected safe libraries to be available, got error: %v", err)
 	}
 }
 


### PR DESCRIPTION
### Motivation
- Remediate a critical vulnerability where user-supplied workflow Lua scripts were executed in an unrestricted gopher-lua state, allowing access to `os`/`io`/`package` and enabling host-level command execution and file access.

### Description
- Replace direct `lua.NewState()` usage with a new `newSandboxedLuaState()` and update `executeLuaScript` to call it (`internal/workflow_manager/workflow_manager.go`).
- `newSandboxedLuaState()` creates the state with `lua.Options{SkipOpenLibs: true}`, opens only safe libraries (`base`, `table`, `string`, `math`, `coroutine`), and removes dangerous globals (`os`, `io`, `package`, `debug`, `require`, `module`, `dofile`, `loadfile`).
- Add unit tests that verify dangerous APIs are blocked and safe libraries still work (`internal/workflow_manager/workflow_manager_test.go`).
- Changes are limited to the workflow manager implementation and tests to preserve existing workflow functionality while preventing host escape.

### Testing
- Ran `go test ./internal/workflow_manager` and the package tests passed successfully.
- Ran `go test -count=1 ./internal/workflow_manager -run 'TestNewSandboxedLuaState'` and the targeted sandboxing tests passed successfully.
- Unit tests exercise both blocking of `os`/`io`/`require` and availability of `string`/`math` primitives to confirm behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4c49d1de48320a32f6dabd2f8c012)